### PR TITLE
Add DAW Controller support for various Arturia controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,173 @@ DreamDexed is a [MiniDexed](https://github.com/probonopd/MiniDexed) fork with th
 - [ ] Overlay Menu for easier parameter changes
 - [ ] MIDI Controller DAW integration
 
+# DreamDexed Arturia fork
+
+This is a fork of DreamDexed that integrates better with Arturia keyboards.
+
+Maybe someday it will be part of the DreamDexed
+
+## Enabling
+
+This feature can be enabled in the minidexed.ini with:
+```
+DAWControllerEnabled=1
+```
+
+## Features
+
+### Controller Display, Main Encoder
+The controller display in DAW mode shows the DreamDexed menu.
+
+With the main encoder you can navigate in the menu.
+
+The Home is the shift+Main click
+
+Supported:
+- MiniLab 3 (tested)
+- KeyLab mkII (tested)
+- Keylab Essential
+- Keylab Essential 3
+
+### MiniLab 3 features:
+
+#### Encoders
+
+By holding down shift will bring up an overlay menu, where you can see and adjust what the encoders do.
+
+You can use the main encoder to select the current encoding page.
+
+Short pressing the shift will show the actual values.
+
+Holding down the shift will goes back to the normal menu.
+
+This overlay menu is context-aware, it is different if you are in the effect menu, or in a TG menu.
+
+If you are in a TG menu, it only affects the selected TG.
+
+If you are in the main menu, it affects the TGs on the first TG's channel.
+
+- Main Overlay 1 (default)
+  - Cutoff, Resonance, FX1Send, FX2Send
+  - PortamentoTime, Program, Volume, MasterVolume
+  - Faders: ChG 1 Vol, ChG 2 Vol, ChG 3 Vol, ChG 4 Vol
+
+- Effect Overlay 1
+  - MasterEQLow, MasterEQMid, MasterEQHigh, MasterEQGain
+  - MasterEQLowMidFreq, MasterEQMidHighFreq, None, None
+  - Faders: MasterEQLow, MasterEQMid, MasterEQHigh, MasterEQGain
+
+- Effect Overlay 2
+  - MasterCREnable, MasterCRPreGain, MasterCRAttack, MasterCRRelease
+  - MasterCRThresh, MasterCRRatio, MasterCRHPFilter, None
+  - Faders: MasterCRPreGain, MasterCRAttack, MasterCRRelease, MasterCRThresh
+
+- Main Overlay 2
+  - Pan1, Pan2, Pan3, Pan4
+  - Det1, Det2, Det3, Det4
+  - Faders: TG1 Vol, TG2 Vol, TG3 Vol, TG4 Vol
+
+- Main Overlay 3
+  - Pan5, Pan6, Pan7, Pan8
+  - Det5, Det6, Det7, Det8
+  - Faders: TG5 Vol, TG6 Vol, TG7 Vol, TG8 Vol
+
+- TG Overlay 1
+  - Cutoff, Resonance, FX1Send, FX2Send
+  - MasterTune, PortamentoTime, Volume, Pan
+  - Faders: Cutoff, FX1Send, FX2Send, Volume
+
+- TG Overlay 2
+  - MIDIChannel, Program, None, PitchBendRange
+  - PortamentoGlissando, MonoMode, None, PitchBendStep
+
+- TG Overlay 3
+  - TGEQLow, TGEQMid, TGEQHigh, TGEQGain
+  - TGEQLowMidFreq, TGEQMidHighFreq, None, None
+  - Faders: TGEQLow, TGEQMid, TGEQHigh, TGEQGain
+
+- TG Overlay 4
+  - CompressorEnable, CompressorPreGain, CompressorMakeupGain, None
+  - CompressorAttack, CompressorRelease, CompressorThresh, CompressorRatio
+  - Faders: CompressorPreGain, CompressorAttack, CompressorRelease, CompressorThresh
+
+- TG Overlay 5
+  - MWRange, MWPitch, FCRange, FCPitch
+  - MWEGBias, MWAmplitude, FCEGBias, FCAmplitude
+
+- TG Overlay 6
+  - BCRange, BCPitch, ATRange, ATPitch
+  - BCEGBias, BCAmplitude, ATEGBias, ATAmplitude
+
+- Voice Overlay 1
+  - ALGORITHM, FEEDBACK, TRANSPOSE, None,
+  - None, None, None, None
+
+- Voice Overlay 2
+  - PITCH_EG_R1, PITCH_EG_R2, PITCH_EG_R3, PITCH_EG_R4
+  - PITCH_EG_L1, PITCH_EG_L2, PITCH_EG_L3, PITCH_EG_L4
+  - Faders: PITCH_EG_L1, PITCH_EG_L2, PITCH_EG_L3, PITCH_EG_L4
+
+- Voice Overlay 3
+  - OSC_KEY_SYNC, LFO_SPEED, LFO_DELAY, LFO_PITCH_MOD_DEP
+  - LFO_SYNC, LFO_WAVE, LFO_PITCH_MOD_SENS, LFO_AMP_MOD_DEP
+
+- OP Overlay 1
+  - OP_OUTPUT_LEV, OP_FREQ_COARSE, OP_FREQ_FINE, OP_OSC_DETUNE,
+  - OP_OSC_MODE, OP_ENABLE, None, None
+
+- OP Overlay 2
+  - OP_EG_R1, OP_EG_R2, P_EG_R3, OP_EG_R4
+  - OP_EG_L1, OP_EG_L2, OP_EG_L3, OP_EG_L4,
+  - Faders: OP_EG_L1, OP_EG_L2, OP_EG_L3, OP_EG_L4,
+
+- OP Overlay 3
+  - OP_LEV_SCL_BRK_PT, OP_SCL_LEFT_DEPTH, OP_SCL_RGHT_DEPTH, OP_AMP_MOD_SENS
+  - OP_OSC_RATE_SCALE, OP_SCL_LEFT_CURVE, OP_SCL_RGHT_CURVE, OP_KEY_VEL_SENS
+
+In the Main overlay you can reach the TG and voice overlays also.
+
+In the voice overlay there is a page for every OP control also, with the 6 operator and with an encoder which sets all.
+
+#### Pads on Bank A
+- Mono/Poly mode
+- Portamento enable/disable, hard press to enable/disable Portamento Glissando
+- Sostenuto
+- Sustain
+- All Sound Off
+- Hold2
+- None
+- Channel AfterTouch Pad
+
+#### Pads on Bank B
+- Short press a TG will enable/disable that TG
+- Long press will enable/disable all the TG on the TG's channel
+- Hard press will enable only that TG (it uses the pad's AT messsages)
+
+
+### KeyLab mkII features
+
+#### Faders
+- The faders 1-8 adjust the volume of the MIDI channels of the current performance
+- The fader 9 adjusts the master volume.
+
+#### Encoders
+- Cutoff, Resonance, Portamento Time
+- None, None, Dry Level, FX1 Send, FX2 Send, None
+
+#### DAW buttons
+- Mono/Poly mode
+- Portamento enable/disable, hard press to enable/disable Portamento Glissando
+- Sostenuto
+- Sustain
+- Hold2
+
+#### Track select buttons
+- Short press a TG will enable/disable that TG
+- Long press will enable only that TG
+
+
+
 ![minidexed](https://user-images.githubusercontent.com/2480569/161813414-bb156a1c-efec-44c0-802a-8926412a08e0.jpg)
 
 DreamDexed is a FM synthesizer closely modeled on the famous DX7 by a well-known Japanese manufacturer running on a bare metal Raspberry Pi (without a Linux kernel or operating system). On Raspberry Pi 2 and larger, it can run 8 tone generators, not unlike the TX816/TX802 (8 DX7 instances without the keyboard in one box). [Featured by HACKADAY](https://hackaday.com/2022/04/19/bare-metal-gives-this-pi-some-classic-synths/), [Adafruit](https://blog.adafruit.com/2022/04/25/free-yamaha-dx7-synth-emulator-on-a-raspberry-pi/), [The MagPi magazine](https://magpi.raspberrypi.com/articles/mini-dexed) (Issue 142 June 2024, [PDF](https://magpi.raspberrypi.com/issues/142)) and [Synth Geekery](https://www.youtube.com/watch?v=TDSy5nnm0jA).

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,8 @@ OBJS = main.o kernel.o minidexed.o config.o userinterface.o uimenu.o ddfont8x16.
        zyn/CombFilterBank.o zyn/Sympathetic.o \
        butter.o \
        arm_float_to_q23.o arm_zip_f32.o arm_scale_zip_f32.o \
-       net/ftpdaemon.o net/ftpworker.o net/applemidi.o net/udpmidi.o net/mdnspublisher.o udpmididevice.o
+       net/ftpdaemon.o net/ftpworker.o net/applemidi.o net/udpmidi.o net/mdnspublisher.o udpmididevice.o \
+       dawcontroller.o
 
 EXTRACLEAN = $(OBJS) $(OBJS:.o=.d)
 

--- a/src/common.h
+++ b/src/common.h
@@ -2,6 +2,8 @@
 #ifndef _common_h
 #define _common_h
 
+#define ARRAY_LENGTH(x) (sizeof(x) / sizeof((x)[0]))
+
 inline long maplong(long x, long in_min, long in_max, long out_min, long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
@@ -15,6 +17,12 @@ inline float32_t mapfloat(int val, int in_min, int in_max, float32_t out_min, fl
 {
   return (val - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
+
+inline long mapfloatr(int val, int in_min, int in_max, float32_t out_min, float32_t out_max)
+{
+  return lround((val - in_min) * (out_max - out_min) / (in_max - in_min) + out_min);
+}
+
 
 #define constrain(amt, low, high) ({ \
   __typeof__(amt) _amt = (amt); \

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -229,7 +229,9 @@ void CConfig::Load (void)
 	m_MIDIButtonActionBankDown = m_Properties.GetString ("MIDIButtonActionBankDown", "");
 	m_MIDIButtonActionTGUp = m_Properties.GetString ("MIDIButtonActionTGUp", "");
 	m_MIDIButtonActionTGDown = m_Properties.GetString ("MIDIButtonActionTGDown", "");
-	
+
+	m_bDAWControllerEnabled = m_Properties.GetNumber ("DAWControllerEnabled", 0) != 0;
+
 	m_bEncoderEnabled = m_Properties.GetNumber ("EncoderEnabled", 0) != 0;
 	m_nEncoderPinClock = m_Properties.GetNumber ("EncoderPinClock", 10);
 	m_nEncoderPinData = m_Properties.GetNumber ("EncoderPinData", 9);
@@ -846,6 +848,11 @@ const char *CConfig::GetMIDIButtonActionTGUp (void) const
 const char *CConfig::GetMIDIButtonActionTGDown (void) const
 {
 	return m_MIDIButtonActionTGDown.c_str();
+}
+
+bool CConfig::GetDAWControllerEnabled (void) const
+{
+	return m_bDAWControllerEnabled;
 }
 
 bool CConfig::GetEncoderEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -255,6 +255,8 @@ public:
 	const char *GetMIDIButtonActionTGUp (void) const;
 	const char *GetMIDIButtonActionTGDown (void) const;
 
+	bool GetDAWControllerEnabled (void) const;
+
 	// KY-040 Rotary Encoder
 	// GPIO pin numbers are chip numbers, not header positions
 	bool GetEncoderEnabled (void) const;
@@ -412,6 +414,8 @@ private:
 	unsigned m_nMIDIButtonBankDown;
 	unsigned m_nMIDIButtonTGUp;
 	unsigned m_nMIDIButtonTGDown;
+
+	bool m_bDAWControllerEnabled;
 
 	bool m_bEncoderEnabled;
 	unsigned m_nEncoderPinClock;

--- a/src/dawcontroller.cpp
+++ b/src/dawcontroller.cpp
@@ -1,0 +1,2441 @@
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2024  The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/string.h>
+
+#include "dawcontroller.h"
+#include "midikeyboard.h"
+#include "minidexed.h"
+#include "midi.h"
+
+#define LINELEN 18
+
+#define MIDI_DAW_CHANGE 0b10000
+#define MIDI_DAW_VOICE 1
+#define MIDI_DAW_TOGGLE_MONO 3
+#define MIDI_DAW_TOGGLE_PORTA_GLISS 4
+#define MIDI_DAW_TOGGLE_TG 5
+#define MIDI_DAW_SELECT_TG 6
+#define MIDI_DAW_SELECT_CHAN_TG 7
+#define MIDI_DAW_MENU_SELECT 8
+#define MIDI_DAW_MENU_BACK 9
+#define MIDI_DAW_MENU_PREV 10
+#define MIDI_DAW_MENU_NEXT 11
+#define MIDI_DAW_MENU_PRESS_PREV 12
+#define MIDI_DAW_MENU_PRESS_NEXT 13
+#define MIDI_DAW_MENU_HOME 14
+#define MIDI_DAW_DISPLAY_MODE_TOGGLE 17
+#define MIDI_DAW_ENC_VALUES_TOGGLE 18
+#define MIDI_DAW_ENC_0 20
+#define MIDI_DAW_ENC_1 21
+#define MIDI_DAW_ENC_2 22
+#define MIDI_DAW_ENC_3 23
+#define MIDI_DAW_ENC_4 24
+#define MIDI_DAW_ENC_5 25
+#define MIDI_DAW_ENC_6 26
+#define MIDI_DAW_ENC_7 27
+#define MIDI_DAW_ENC_8 28
+#define MIDI_DAW_FADER_0 29
+#define MIDI_DAW_FADER_1 30
+#define MIDI_DAW_FADER_2 31
+#define MIDI_DAW_FADER_3 32
+#define MIDI_DAW_FADER_4 33
+#define MIDI_DAW_FADER_5 34
+#define MIDI_DAW_FADER_6 35
+#define MIDI_DAW_FADER_7 36
+#define MIDI_DAW_MASTER_VOLUME 37
+
+
+static void ArturiaDisplayWrite (CMIDIKeyboard *pKeyboard, const u8 *pHdr, const unsigned nHdrSize,
+	size_t nLineMaxLen, const bool bFill1, const bool bFill2, const char *pMenu,
+	const char *pParam, const char *pValue,
+	const bool bArrowLeft, const bool bArrowRight, const bool bShowArrows)
+{
+	size_t nParamLen = std::min (nLineMaxLen, strlen (pParam));
+	size_t nMenuLen = strlen (pMenu);
+	size_t nFill1Len = bFill1 && nLineMaxLen > nParamLen + nMenuLen ?
+		nLineMaxLen - nParamLen - nMenuLen : 1;
+
+	nFill1Len = std:: min (nLineMaxLen - nParamLen, nFill1Len);
+	nMenuLen = std::min (nLineMaxLen - nParamLen - nFill1Len, nMenuLen);
+
+	size_t nLine1Len = nParamLen + nFill1Len + nMenuLen;
+
+	size_t nArrowsLen = bShowArrows ? 2 : 0;
+	size_t nValueLen = std::min (nLineMaxLen - nArrowsLen, strlen (pValue));
+	size_t nFill2Len = bFill2 ? nLineMaxLen - nArrowsLen - nValueLen : 0;
+	size_t nLine2Len = nValueLen + nFill2Len + nArrowsLen;
+
+	size_t nOffset = 0;
+
+	uint8_t pLines[nHdrSize + nLine1Len + 2 + nLine2Len + 2];
+
+	memcpy (pLines, pHdr, nHdrSize);
+	nOffset += nHdrSize;
+
+	memcpy (&pLines[nOffset], pParam, nParamLen);
+	nOffset += nParamLen;
+
+	memset (&pLines[nOffset], ' ', nFill1Len);
+	nOffset += nFill1Len;
+
+	memcpy (&pLines[nOffset], pMenu, nMenuLen);
+	nOffset += nMenuLen;
+
+	pLines[nOffset++] = 0x00;
+	pLines[nOffset++] = 0x02;
+
+	if (bShowArrows)
+		pLines[nOffset++] = bArrowLeft ? '<' : ' ';
+
+	memcpy (&pLines[nOffset], pValue, nValueLen);
+	nOffset += nValueLen;
+
+	memset (&pLines[nOffset], ' ', nFill2Len);
+	nOffset += nFill2Len;
+
+	if (bShowArrows)
+		pLines[nOffset++] = bArrowRight ? '>' : ' ';
+
+	pLines[nOffset++] = 0x00;
+	pLines[nOffset++] = 0xF7;
+
+	// block character (0xFF) is not supported over MIDI, change to 0x7f
+	for (unsigned i = 0; i < sizeof pLines; ++i)
+		if (pLines[i] == 0xFF)
+			pLines[i] = 0x7F;
+
+	pKeyboard->SendDisplay (pLines, nOffset, 0);
+}
+
+enum ControlType
+{
+	CT_KNOB = 3,
+	CT_FADER,
+	CT_PAD,
+};
+
+enum HideAfter
+{
+	HA_NO = 0,
+	HA_YES = 2,
+};
+
+static std::string to_string (int nValue, int nWidth)
+{
+	return std::to_string(nValue);
+}
+
+static std::string to_percent (int nValue, int nWidth)
+{
+	return std::to_string(mapfloatr (nValue, 0, 127, 0, 100)) + "%";
+}
+
+static std::string to_on_off (int nValue, int nWidth)
+{
+	return nValue < 64 ? "Off" : "On";
+}
+
+static std::string to_selected (int nValue, int nWidth)
+{
+	return nValue < 64 ? "Deselected" : "Selected";
+}
+
+std::string to_midi_channel (int nValue)
+{
+	switch (nValue)
+	{
+	case CMIDIDevice::OmniMode:	return "Omni";
+	case CMIDIDevice::Disabled:	return "Off";
+	default: return std::to_string (nValue + 1);
+	}
+}
+
+static void ArturiaDisplayInfoWrite (CMIDIKeyboard *pKeyboard, const uint8_t pDisplayHdr[3], ControlType Type, u8 uValue, const char *pName, const char *pValue)
+{
+	const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, pDisplayHdr[0], pDisplayHdr[1], pDisplayHdr[2], 0x1F, Type, HA_NO, uValue, 0x00, 0x00, 0x01};
+
+	int nLine1Len = strlen (pName);
+	int nLine2Len = strlen (pValue);
+	int nOffset = 0;
+
+	uint8_t pLines[sizeof pHdr + nLine1Len + 2 + nLine2Len + 2];
+
+	memcpy (pLines, pHdr, sizeof pHdr);
+	nOffset += sizeof pHdr;
+
+	memcpy (pLines + nOffset, pName, nLine1Len);
+	nOffset += nLine1Len;
+
+	pLines[nOffset++] = 0x00;
+	pLines[nOffset++] = 0x02;
+
+	memcpy (pLines + nOffset, pValue, nLine2Len);
+	nOffset += nLine2Len;
+
+	pLines[nOffset++] = 0x00;
+	pLines[nOffset++] = 0xf7;
+
+	pKeyboard->SendDisplay (pLines, nOffset, 0);
+}
+
+static void ArturiaShowNewCCValue (CMIDIKeyboard *pKeyboard, const uint8_t pDisplayHdr[3], u8 ucCh, u8 ucCC, u8 ucValue)
+{
+	char line1[LINELEN];
+	char line2[LINELEN];
+
+	switch (ucCC)
+	{
+	case MIDI_CC_PORTAMENTO_TIME:
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Portamento Time", line2);
+		break;
+	case MIDI_CC_VOLUME:
+		snprintf(line1, LINELEN, "Volume Ch %d", ucCh + 1);
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 100));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_FADER, ucValue, line1, line2);
+		break;
+	case MIDI_CC_FREQUENCY_CUTOFF:
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Cutoff", line2);
+		break;
+	case MIDI_CC_RESONANCE:
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Resonance", line2);
+		break;
+	case MIDI_CC_EFFECT1_SEND:
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Effect1 Send", line2);
+		break;
+	case MIDI_CC_EFFECT2_SEND:
+		snprintf(line2, LINELEN, "%ld%%", mapfloatr (ucValue, 0, 127, 0, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Effect2 Send", line2);
+		break;
+	case MIDI_CC_DETUNE_LEVEL:
+		snprintf(line2, LINELEN, "%ld", mapfloatr (ucValue, 1, 127, -99, 99));
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Detune", line2);
+		break;
+	case MIDI_CC_PAN_POSITION:
+		snprintf(line2, LINELEN, "%d", ucValue);
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_KNOB, ucValue, "Pan", line2);
+		break;
+	case MIDI_CC_SUSTAIN:
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_PAD, ucValue, "Sustain", ucValue > 64 ? "On" : "Off");
+		break;
+	case MIDI_CC_PORTAMENTO:
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_PAD, ucValue, "Portamento", ucValue > 64 ? "On" : "Off");
+		break;
+	case MIDI_CC_SOSTENUTO:
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_PAD, ucValue, "Sostenuto", ucValue > 64 ? "On" : "Off");
+		break;
+	case MIDI_CC_HOLD2:
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_PAD, ucValue, "Hold", ucValue > 64 ? "On" : "Off");
+		break;
+	case MIDI_CC_ALL_SOUND_OFF:
+		ArturiaDisplayInfoWrite (pKeyboard, pDisplayHdr, CT_PAD, ucValue, "All Sound Off", "");
+		break;
+	}
+}
+
+static void HandleMenuEvents (CUserInterface *pUI, u8 ucDC)
+{
+	switch (ucDC)
+	{
+	case MIDI_DAW_MENU_SELECT:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventSelect);
+		break;
+	case MIDI_DAW_MENU_BACK:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventBack);
+		break;
+	case MIDI_DAW_MENU_PREV:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventStepDown);
+		break;
+	case MIDI_DAW_MENU_NEXT:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventStepUp);
+		break;
+	case MIDI_DAW_MENU_PRESS_PREV:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventPressAndStepDown);
+		break;
+	case MIDI_DAW_MENU_PRESS_NEXT:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventPressAndStepUp);
+		break;
+	case MIDI_DAW_MENU_HOME:
+		pUI->MIDIEventHandler (CUIMenu::MenuEventHome);
+		break;
+	}
+}
+
+class CDAWConnection
+{
+public:
+	virtual void DisplayWrite (const char *pMenu, const char *pParam,
+				   const char *pValue, bool bArrowDown, bool bArrowUp) = 0;
+	virtual void UpdateState () = 0;
+	virtual void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG) = 0;
+	virtual void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) = 0;
+	virtual ~CDAWConnection (void) = default;
+
+	static const unsigned nDefaultDisplayUpdateDelay = 2000;
+};
+
+struct CColor
+{
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
+};
+
+bool operator==(const CColor& l, const CColor& r)
+{
+	return l.r == r.r && l.g == r.g && l.b == r.b;
+}
+
+bool operator!=(const CColor& l, const CColor& r)
+{
+	return !(l == r);
+}
+
+static CColor padColors[8] = {
+	{0x3F, 0x3F, 0x11},
+	{0x11, 0x11, 0x3F},
+	{0x3F, 0x11, 0x3F},
+	{0x11, 0x3F, 0x11},
+	{0x3F, 0x11, 0x11},
+	{0x11, 0x3F, 0x3F},
+	{0x00, 0x00, 0x00},
+	{0x00, 0x00, 0x00},
+};
+
+static CColor altPadColors[8] = {
+	{0x3F, 0x3F, 0x11},
+	{0x11, 0x21, 0x3F},
+	{0x3F, 0x11, 0x3F},
+	{0x11, 0x3F, 0x11},
+	{0x3F, 0x11, 0x11},
+	{0x00, 0x00, 0x00},
+	{0x00, 0x00, 0x00},
+	{0x00, 0x00, 0x00},
+};
+
+static CColor chColors[CMIDIDevice::TChannel::Disabled + 1] = {
+	{0x7F, 0x00, 0x00}, // 1
+	{0x7F, 0x40, 0x00}, // 2
+	{0x7F, 0x40, 0x40}, // 3
+	{0x7F, 0x40, 0x7F}, // 4
+	{0x7F, 0x7F, 0x00}, // 5
+	{0x7F, 0x7F, 0x40}, // 6
+	{0x7F, 0x7F, 0x7F}, // 7
+	{0x40, 0x00, 0x40}, // 8
+	{0x40, 0x40, 0x00}, // 9
+	{0x40, 0x40, 0x40}, // 10
+	{0x40, 0x40, 0x7F}, // 11
+	{0x40, 0x7F, 0x00}, // 12
+	{0x40, 0x7F, 0x40}, // 13
+	{0x40, 0x7F, 0x7F}, // 14
+	{0x00, 0x00, 0x40}, // 15
+	{0x00, 0x40, 0x00}, // 16
+	{0x7F, 0x7F, 0x7F}, // Omni
+	{0x00, 0x00, 0x00}, // Disabled
+};
+
+static CColor invalidColor = {0x80, 0x80, 0x80};
+
+static CColor chColors_kl2[CMIDIDevice::TChannel::Disabled + 1] = {
+	{0x1F, 0x00, 0x00}, // 1
+	{0x1F, 0x10, 0x00}, // 2
+	{0x1F, 0x10, 0x10}, // 3
+	{0x1F, 0x10, 0x1F}, // 4
+	{0x1F, 0x1F, 0x00}, // 5
+	{0x1F, 0x1F, 0x10}, // 6
+	{0x1F, 0x1F, 0x1F}, // 7
+	{0x10, 0x00, 0x10}, // 8
+	{0x10, 0x10, 0x00}, // 9
+	{0x10, 0x10, 0x10}, // 10
+	{0x10, 0x10, 0x1F}, // 11
+	{0x10, 0x1F, 0x00}, // 12
+	{0x10, 0x1F, 0x10}, // 13
+	{0x10, 0x1F, 0x1F}, // 14
+	{0x00, 0x00, 0x10}, // 15
+	{0x00, 0x10, 0x00}, // 16
+	{0x1F, 0x1F, 0x1F}, // Omni
+	{0x00, 0x00, 0x00}, // Disabled
+};
+
+class CMiniLab3DawConnection : public CDAWConnection
+{
+public:
+	CMiniLab3DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI);
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp) override;
+	void UpdateState () override;
+	void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG) override;
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) override;
+private:
+	enum TPadID {
+		MonoPad = 0,
+		PortamentoPad = 1,
+		SostenutoPad = 2,
+		SustainPad = 3,
+		SoundOffPad = 4,
+		HoldPad = 5,
+		TBDPad7 = 6,
+		ATPad = 7,
+	};
+	enum TBankID {
+		BankA = 0x34,
+		BankB = 0x44,
+	};
+
+	static const u8 AllOP = 8;
+
+	void DisplayWriteSimple (const char *pMenu, const char *pParam, const char *pValue);
+
+	static void s_UpdateDisplay (TKernelTimerHandle hTimer, void *pParam, void *pContext);
+	void QueueUpdateDisplay (unsigned msec);
+	void UpdateDisplay ();
+	void ShowEncoderDisplay ();
+	void ShowValueDisplay ();
+
+	void UpdateEncoder (uint8_t ucEncID, uint8_t ucValue);
+	void UpdateEncoders ();
+	void UpdateTGColors ();
+	void UpdateMonoColor ();
+	void UpdatePortamentoColor ();
+	void UpdateATColor (u8 ucAT);
+	void UpdateChanGroups ();
+
+	void SetPadColor (TBankID BankID, TPadID PadID, u8 state);
+	void SetPadColor (TBankID BankID, TPadID PadID, u8 state, u8 state2);
+	void SetPadColor (TBankID BankID, TPadID PadID, CColor color, u8 state);
+	void SetPadColor (TBankID BankID, TPadID PadID, CColor color);
+
+	void SetChannelAT (u8 ucValue);
+	void SetVoice (u8 ucChannel, u8 ucVoice);
+	void SetAlgorithm (u8 ucChannel, u8 ucAlgorithm);
+	void SetEncoder (u8 ucChannel, u8 ucEncID, u8 ucVoice);
+	void ToggleMonoMode (u8 ucChannel);
+	void TogglePortamentoGlisssando (u8 ucChannel);
+	void ToggleTG (u8 ucTG);
+	void SelectTG (u8 ucTG);
+	void SelectChanTG (u8 ucTG);
+
+	CMiniDexed *m_pSynthesizer;
+	CMIDIKeyboard *m_pKeyboard;
+	CConfig *m_pConfig;
+	CUserInterface *m_pUI;
+
+	bool m_bDisableEncoderUpdate = false;
+
+	CUIMenu::TCPageType m_encoderPageType = CUIMenu::PageMain;
+	u8 m_ucEncoderPage = 0;
+	u8 m_ucEncoderOP = 0;
+	u8 m_ucEncoderTG = 0;
+	CUIMenu::TCParameterInfo *m_pEncoders;
+
+	enum DisplayState {
+		DisplayMenu,
+		DisplayEncoder,
+		DisplayValues,
+	};
+	DisplayState m_DisplayState = DisplayMenu;
+
+	static constexpr size_t nEncoder = 8;
+	static constexpr size_t nFader = 4;
+
+	CUIMenu::TCParameterInfo m_pMainEncoders[1 + 0 + 2 + 5 + 3 + 22][nEncoder + nFader] = {
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCutoff},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterResonance},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX1Send, "FX1Send", "FX1"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX2Send, "FX2Send", "FX2"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPortamentoTime},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterProgram},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ToString=to_percent},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterVolume, "Master Vol", "MVo", .ToString=to_percent},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ChG=1, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ChG=2, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ChG=3, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ChG=4, .ToString=to_percent},
+		},
+		/*{
+			// Effect Master EQ
+		},
+		{
+			// Effect Limiter
+		},*/
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn1", .TG=1, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn2", .TG=2, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn3", .TG=3, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn4", .TG=4, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt1", .TG=1},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt2", .TG=2},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt3", .TG=3},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt4", .TG=4},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=1, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=2, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=3, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=4, .ToString=to_percent},
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn5", .TG=5, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn6", .TG=6, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn7", .TG=7, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .Short="Pn8", .TG=8, .ToString=to_string},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt5", .TG=5},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt6", .TG=6},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt7", .TG=7},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune, .Short="Dt8", .TG=8},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=5, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=6, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=7, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .TG=8, .ToString=to_percent},
+		},
+	};
+
+	CUIMenu::TCParameterInfo m_pEffectEncoders[0][nEncoder + nFader] = {
+		/*{
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQLow, "MaEQ Low"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQMid, "MaEQ Mid"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQHigh, "MaEQ High"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQGain, "MaEQ Gain"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQLowMidFreq, "MaEQ LowMid"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQMidHighFreq, "MaEQ MidHigh"},
+			{CUIMenu::ParameterNone},
+			{CUIMenu::ParameterNone},
+
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQLow, "MaEQ Low"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQMid, "MaEQ Mid"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQHigh, "MaEQ High"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterEQGain, "MaEQ Gain"},
+		},
+		{
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorEnable, "Master Compressor"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorPreGain, "MaCR Pre Gain"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorAttack, "MaCR Attack"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorRelease, "MaCR Release"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorThresh, "MaCR Thresh"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorRatio, "MaCR Ratio"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorHPFilterEnable, "MaCR HP Filter"},
+			{CUIMenu::ParameterNone},
+
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorPreGain, "MaCR Pre Gain"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorAttack, "MaCR Attack"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorRelease, "MaCR Release"},
+			{CUIMenu::ParameterGlobal, CMiniDexed::ParameterMasterCompressorThresh, "MaCR Thresh"},
+		},*/
+	};
+
+	CUIMenu::TCParameterInfo m_pTGEncoders[6 + 3 + 22][nEncoder + nFader] = {
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCutoff},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterResonance},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX1Send, "FX1Send", "FX1"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX2Send, "FX2Send", "FX2"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMasterTune},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPortamentoTime},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ToString=to_percent},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPan, .ToString=to_string},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCutoff},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX1Send, "FX1Send", "FX1"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFX2Send, "FX2Send", "FX2"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterVolume, .ToString=to_percent},
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMIDIChannel},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterProgram},
+			{CUIMenu::ParameterNone},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPitchBendRange},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPortamentoGlissando},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMonoMode},
+			{CUIMenu::ParameterNone},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterPitchBendStep},
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQLow, "TGEQ Low"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQMid, "TGEQ Mid"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQHigh, "TGEQ High"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQGain, "TGEQ Gain"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQLowMidFreq, "TGEQ LowMid"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQMidHighFreq, "TGEQ MidHigh"},
+			{CUIMenu::ParameterNone},
+			{CUIMenu::ParameterNone},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQLow, "TGEQ Low"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQMid, "TGEQ Mid"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQHigh, "TGEQ High"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterEQGain, "TGEQ Gain"},
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorEnable, "Compressor"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorPreGain, "Pre Gain"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorMakeupGain, "Makeup Gain"},
+			{CUIMenu::ParameterNone},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorAttack, "Attack"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorRelease, "Release"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorThresh, "Thresh"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorRatio, "Ratio"},
+
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorPreGain, "Pre Gain"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorAttack, "Attack"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorRelease, "Release"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterCompressorThresh, "Thresh"},
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMWRange},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMWPitch, "MW Pitch", "MWP"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFCRange},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFCPitch, "FC Pitch", "FCP"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMWEGBias, "MW EG Bias", "MWEB"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterMWAmplitude, "MW Amp", "MWA"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFCEGBias, "FC EG Bias", "FCEB"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterFCAmplitude, "FC Amp", "FCA"},
+
+		},
+		{
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterBCRange},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterBCPitch, "BC Pitch", "BCP"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterATRange},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterATPitch, "AT Pitch", "ATP"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterBCEGBias, "BC EG Bias", "BCEB"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterBCAmplitude, "BC Amp", "BCA"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterATEGBias, "AT EG Bias", "ATEB"},
+			{CUIMenu::ParameterTG, CMiniDexed::TGParameterATAmplitude, "AT Amp", "ATA"},
+		},
+	};
+
+	CUIMenu::TCParameterInfo m_pVoiceEncoders[3 + 22][nEncoder + nFader] = {
+		{
+			{CUIMenu::ParameterVoice, DEXED_ALGORITHM},
+			{CUIMenu::ParameterVoice, DEXED_FEEDBACK},
+			{CUIMenu::ParameterVoice, DEXED_TRANSPOSE},
+		},
+		{
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_R1},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_R2},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_R3},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_R4},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L1},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L2},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L3},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L4},
+
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L1},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L2},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L3},
+			{CUIMenu::ParameterVoice, DEXED_PITCH_EG_L4},
+		},
+		{
+			{CUIMenu::ParameterVoice, DEXED_OSC_KEY_SYNC},
+			{CUIMenu::ParameterVoice, DEXED_LFO_SPEED},
+			{CUIMenu::ParameterVoice, DEXED_LFO_PITCH_MOD_SENS},
+			{CUIMenu::ParameterVoice, DEXED_LFO_PITCH_MOD_DEP},
+			{CUIMenu::ParameterVoice, DEXED_LFO_SYNC},
+			{CUIMenu::ParameterVoice, DEXED_LFO_DELAY},
+			{CUIMenu::ParameterVoice, DEXED_LFO_WAVE},
+			{CUIMenu::ParameterVoice, DEXED_LFO_AMP_MOD_DEP},
+		},
+	};
+
+	CUIMenu::TCParameterInfo m_pOPEncoders[3][nEncoder + nFader] = {
+		{
+			{CUIMenu::ParameterOP, DEXED_OP_OUTPUT_LEV},
+			{CUIMenu::ParameterOP, DEXED_OP_FREQ_COARSE},
+			{CUIMenu::ParameterOP, DEXED_OP_FREQ_FINE},
+			{CUIMenu::ParameterOP, DEXED_OP_OSC_DETUNE},
+			{CUIMenu::ParameterOP, DEXED_OP_OSC_MODE},
+			{CUIMenu::ParameterOP, DEXED_OP_ENABLE},
+		},
+		{
+			{CUIMenu::ParameterOP, DEXED_OP_EG_R1},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_R2},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_R3},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_R4},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L1},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L2},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L3},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L4},
+
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L1},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L2},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L3},
+			{CUIMenu::ParameterOP, DEXED_OP_EG_L4},
+		},
+		{
+			{CUIMenu::ParameterOP, DEXED_OP_LEV_SCL_BRK_PT},
+			{CUIMenu::ParameterOP, DEXED_OP_SCL_LEFT_DEPTH},
+			{CUIMenu::ParameterOP, DEXED_OP_SCL_RGHT_DEPTH},
+			{CUIMenu::ParameterOP, DEXED_OP_AMP_MOD_SENS},
+			{CUIMenu::ParameterOP, DEXED_OP_OSC_RATE_SCALE},
+			{CUIMenu::ParameterOP, DEXED_OP_SCL_LEFT_CURVE},
+			{CUIMenu::ParameterOP, DEXED_OP_SCL_RGHT_CURVE},
+			{CUIMenu::ParameterOP, DEXED_OP_KEY_VEL_SENS},
+		},
+	};
+
+	TKernelTimerHandle m_DisplayTimer = 0;
+
+	u8 m_ucFirstTG = 0;
+
+	CColor m_PadColorCache[8];
+	CColor m_TGColorCache[8];
+	
+	u8 m_EncoderCache[nEncoder];
+
+	u8 m_ChanGroups[nFader];
+
+	const uint8_t m_pEncoder[3] = {0x04, 0x02, 0x60};
+	TMIDIRoute m_pRouteMap[75] = {
+		{0, 0, MIDI_CONTROL_CHANGE, 14, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_FADER_0, 0xFF}, // Fader1
+		{0, 0, MIDI_CONTROL_CHANGE, 15, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_FADER_1, 0xFF}, // Fader2
+		{0, 0, MIDI_CONTROL_CHANGE, 30, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_FADER_2, 0xFF}, // Fader3
+		{0, 0, MIDI_CONTROL_CHANGE, 31, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_FADER_3, 0xFF}, // Fader4
+
+		{0, 0, MIDI_CONTROL_CHANGE, 118, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Main knob click
+		{0, 0, MIDI_CONTROL_CHANGE, 118, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_SELECT, 0, .bGroup=true},
+		{0, 0, MIDI_CONTROL_CHANGE, 118, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_BACK, 0, .bGroup=true},
+		{0, 0, MIDI_CONTROL_CHANGE, 28, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_PREV, 0xFF, .bGroup=true, .bGroupHold=true}, // Main knob click + rotate
+		{0, 0, MIDI_CONTROL_CHANGE, 28, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_NEXT, 0xFF, .bGroup=true, .bGroupHold=true},
+		
+		{0, 0, MIDI_CONTROL_CHANGE, 119, 0x7F, .bSkip=true}, // Shift + Main knob click
+		{0, 0, MIDI_CONTROL_CHANGE, 119, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_HOME, 0},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 28, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PREV, 0xFF}, // Main knob
+		{0, 0, MIDI_CONTROL_CHANGE, 28, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_NEXT, 0xFF},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 27, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Shift
+		{0, 0, MIDI_CONTROL_CHANGE, 27, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_VALUES_TOGGLE, 0xFF, .bGroup=true},
+		{0, 0, MIDI_CONTROL_CHANGE, 27, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_DISPLAY_MODE_TOGGLE, 0xFF, .bGroup=true},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 86, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_0, 0xFF}, // Knob1
+		{0, 0, MIDI_CONTROL_CHANGE, 87, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_1, 0xFF}, // Knob2
+		{0, 0, MIDI_CONTROL_CHANGE, 89, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_2, 0xFF}, // Knob3
+		{0, 0, MIDI_CONTROL_CHANGE, 90, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_3, 0xFF}, // Knob4
+		{0, 0, MIDI_CONTROL_CHANGE, 110, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_4, 0xFF}, // Knob5
+		{0, 0, MIDI_CONTROL_CHANGE, 111, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_5, 0xFF}, // Knob6
+		{0, 0, MIDI_CONTROL_CHANGE, 116, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_6, 0xFF}, // Knob7
+		{0, 0, MIDI_CONTROL_CHANGE, 117, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_7, 0xFF}, // Knob8
+
+		{0, 9, MIDI_NOTE_ON, 36, 0xFF, .bSkip=true}, // BankA Pad1
+		{0, 9, MIDI_NOTE_OFF, 36, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_MONO, 0x7F},
+	
+		{0, 9, MIDI_NOTE_ON, 37, 0xFF, .bSkip=true, .bGroupHead=true}, // BankA Pad2
+		{0, 9, MIDI_NOTE_OFF, 37, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PORTAMENTO, 0x7F, .bToggle=true, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 37, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_PORTA_GLISS, 0x7F, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 38, 0xFF, .bSkip=true}, // BankA Pad3
+		{0, 9, MIDI_NOTE_OFF, 38, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_SOSTENUTO, 0x7F, .bToggle=true},
+
+		{0, 9, MIDI_NOTE_ON, 39, 0xFF, .bSkip=true}, // BankA Pad4
+		{0, 9, MIDI_NOTE_OFF, 39, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_SUSTAIN, 0x7F, .bToggle=true}, 
+		
+		{0, 9, MIDI_NOTE_ON, 40, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_ALL_SOUND_OFF, 0x7F}, // BankA Pad5
+		{0, 9, MIDI_NOTE_OFF, 40, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_ALL_SOUND_OFF, 0x00},
+
+		{0, 9, MIDI_NOTE_ON, 41, 0xFF, .bSkip=true}, // BankA Pad6
+		{0, 9, MIDI_NOTE_OFF, 41, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_HOLD2, 0x7F, .bToggle=true},
+
+		{0, 9, MIDI_NOTE_ON, 42, 0xFF, .bSkip=true}, // BankA Pad7
+		{0, 9, MIDI_NOTE_OFF, 42, 0xFF, .bSkip=true},
+
+		{0, 9, MIDI_NOTE_ON, 43, 0xFF, .bSkip=true}, // BankA Pad8
+		{0, 9, MIDI_NOTE_OFF, 43, 0xFF, 0, MIDI_CHANNEL_AFTERTOUCH, 0x00, 0xFF},
+		{0, 9, MIDI_AFTERTOUCH, 43, 0xFF, 0, MIDI_CHANNEL_AFTERTOUCH, TMIDIRoute::P2, 0xFF},
+
+		{0, 9, MIDI_NOTE_ON, 44, 0xFF,  .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad1
+		{0, 9, MIDI_NOTE_OFF, 44, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 44, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 0, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 44, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 0, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 45, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad2
+		{0, 9, MIDI_NOTE_OFF, 45, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 1, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 45, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 1, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 45, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 1, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 46, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad3
+		{0, 9, MIDI_NOTE_OFF, 46, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 2, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 46, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 2, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 46, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 2, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 47, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad4
+		{0, 9, MIDI_NOTE_OFF, 47, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 3, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 47, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 3, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 47, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 3, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 48, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad5
+		{0, 9, MIDI_NOTE_OFF, 48, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 4, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 48, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 4, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 48, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 4, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 49, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad6
+		{0, 9, MIDI_NOTE_OFF, 49, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 5, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 49, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 5, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 49, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 5, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 50, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad7
+		{0, 9, MIDI_NOTE_OFF, 50, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 6, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 50, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 6, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 50, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 6, .bGroup=true},
+
+		{0, 9, MIDI_NOTE_ON, 51, 0xFF, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // BankB Pad8
+		{0, 9, MIDI_NOTE_OFF, 51, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 7, .bGroup=true},
+		{0, 9, MIDI_NOTE_OFF, 51, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_CHAN_TG, 7, .bGroup=true},
+		{0, 9, MIDI_AFTERTOUCH, 51, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 7, .bGroup=true},
+
+		{0xFF}, // Sentinel
+	};
+};
+
+CMiniLab3DawConnection::CMiniLab3DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI)
+	:m_pSynthesizer (pSynthesizer), m_pKeyboard (pKeyboard), m_pConfig (pConfig), m_pUI (pUI)
+{
+	static const uint8_t pInit[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x40, 0x6A, 0x21, 0xF7};
+
+	m_pKeyboard->SetRouteMap (m_pRouteMap);
+
+	m_pKeyboard->Send (pInit, sizeof pInit, 0);
+	DisplayWrite ("DreamDexed", "", "On MiniLab 3", 0, 0);
+
+	SetPadColor (BankA, MonoPad, 0);
+	SetPadColor (BankA, PortamentoPad, 0);
+	SetPadColor (BankA, SostenutoPad, 0);
+	SetPadColor (BankA, SustainPad, 0);
+	SetPadColor (BankA, SoundOffPad, 0);
+	SetPadColor (BankA, HoldPad, 0);
+	SetPadColor (BankA, TBDPad7, 0);
+	UpdateATColor (0);
+
+	for (unsigned vIdx = 3,i = 0; i < ARRAY_LENGTH (m_pOPEncoders); ++i)
+		for (unsigned j = 0; j < nEncoder; ++j)
+		{
+			CUIMenu::TCParameterInfo *pInfo = &m_pOPEncoders[i][j];
+			if (!pInfo->Type)
+				continue;
+
+			for (unsigned k = 0; k < 6; ++k)
+				m_pVoiceEncoders[vIdx][k] = {pInfo->Type, pInfo->Parameter, .OP=static_cast<u8>(k+1)};
+			
+			m_pVoiceEncoders[vIdx][7] = {pInfo->Type, pInfo->Parameter, .OP=AllOP};
+
+			vIdx++;
+		}
+
+	assert (sizeof m_pTGEncoders == sizeof *m_pTGEncoders * 6 + sizeof m_pVoiceEncoders);
+	memcpy (m_pTGEncoders + 6, m_pVoiceEncoders, sizeof m_pVoiceEncoders);
+
+	assert (sizeof m_pMainEncoders == sizeof *m_pMainEncoders * 1 + sizeof m_pEffectEncoders + sizeof *m_pMainEncoders * 2 + sizeof *m_pTGEncoders * 5 + sizeof m_pVoiceEncoders);
+	memcpy (m_pMainEncoders + 1, m_pEffectEncoders, sizeof m_pEffectEncoders);
+	memcpy (m_pMainEncoders + 5, m_pTGEncoders + 1, sizeof *m_pTGEncoders * 5);
+	memcpy (m_pMainEncoders + 10, m_pVoiceEncoders, sizeof m_pVoiceEncoders);
+
+	for (unsigned i = 0; i < ARRAY_LENGTH (m_pMainEncoders); ++i)
+		m_pUI->GetParameterInfos (m_pMainEncoders[i], ARRAY_LENGTH (m_pMainEncoders[i]));
+	for (unsigned i = 0; i < ARRAY_LENGTH (m_pTGEncoders); ++i)
+		m_pUI->GetParameterInfos (m_pTGEncoders[i], ARRAY_LENGTH (m_pTGEncoders[i]));
+	for (unsigned i = 0; i < ARRAY_LENGTH (m_pEffectEncoders); ++i)
+		m_pUI->GetParameterInfos (m_pEffectEncoders[i], ARRAY_LENGTH (m_pEffectEncoders[i]));
+	for (unsigned i = 0; i < ARRAY_LENGTH (m_pVoiceEncoders); ++i)
+		m_pUI->GetParameterInfos (m_pVoiceEncoders[i], ARRAY_LENGTH (m_pVoiceEncoders[i]));
+	for (unsigned i = 0; i < ARRAY_LENGTH (m_pOPEncoders); ++i)
+		m_pUI->GetParameterInfos (m_pOPEncoders[i], ARRAY_LENGTH (m_pOPEncoders[i]));
+
+
+	memset (m_PadColorCache, 0xFF, sizeof (m_PadColorCache));
+	memset (m_TGColorCache, 0xFF, sizeof (m_TGColorCache));
+	memset (m_EncoderCache, 0xFF, sizeof (m_EncoderCache));
+
+
+	UpdateMenu (m_encoderPageType, m_ucEncoderPage, m_ucEncoderOP, m_ucEncoderTG);
+	QueueUpdateDisplay (nDefaultDisplayUpdateDelay);
+}
+
+void CMiniLab3DawConnection::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp)
+{
+	const uint8_t page = bArrowDown == bArrowUp ? 0x11 : bArrowDown ? 0x10 : 0x00;
+	const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x02, 0x60, 0x1f, 0x06, 0x00, 0x00, page, 0x00, 0x11, 0x00, 0x01};
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 18, true, false, pMenu, pParam, pValue, false, false, false);
+}
+
+void CMiniLab3DawConnection::DisplayWriteSimple (const char *pMenu, const char *pParam, const char *pValue)
+{
+	const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x02, 0x60, 0x01};
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 18, true, false, pMenu, pParam, pValue, false, false, false);
+}
+
+void CMiniLab3DawConnection::QueueUpdateDisplay (unsigned msec)
+{
+	if (m_DisplayTimer)
+		CTimer::Get ()->CancelKernelTimer (m_DisplayTimer);
+	m_DisplayTimer = CTimer::Get ()->StartKernelTimer (MSEC2HZ (msec), s_UpdateDisplay, this, NULL);
+}
+
+void CMiniLab3DawConnection::s_UpdateDisplay (TKernelTimerHandle hTimer, void *pParam, void *pContext)
+{
+	assert (pParam != NULL);
+	static_cast<CMiniLab3DawConnection*>(pParam)->UpdateDisplay ();
+}
+
+void CMiniLab3DawConnection::UpdateDisplay ()
+{
+	switch (m_DisplayState)
+	{
+		case DisplayMenu:
+			m_pUI->MIDIEventHandler (CUIMenu::MenuEventUpdate);
+		break;
+		case DisplayEncoder:
+			ShowEncoderDisplay ();
+		break;
+		case DisplayValues:
+			ShowValueDisplay ();
+		break;
+	}
+}
+
+void CMiniLab3DawConnection::ShowEncoderDisplay ()
+{
+	static const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x02, 0x60, 0x1f, 0x07, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01};
+	std::string pParam = "";
+	std::string pValue = "";
+	for (unsigned i = 0; i < nEncoder; ++i)
+	{
+		const char *pShort = m_pEncoders[i].Short ?: "...";
+		if (i < 4)
+			pParam = pParam + pShort + " ";
+		else
+			pValue = pValue + pShort + " ";
+	}
+
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 18, false, false, "", pParam.c_str(), pValue.c_str(), false, false, false);
+}
+
+static int GetParameterValue (CMiniDexed *pSynthesizer, CUIMenu::TCParameterInfo *pInfo, uint8_t ucOP, uint8_t ucTG)
+{
+	switch (pInfo->Type)
+	{
+	case CUIMenu::ParameterGlobal:
+		return pSynthesizer->GetParameter (static_cast<CMiniDexed::TParameter>(pInfo->Parameter));
+		break;
+	case CUIMenu::ParameterTG:
+		return pSynthesizer->GetTGParameter (static_cast<CMiniDexed::TTGParameter>(pInfo->Parameter), ucTG);
+		break;
+	case CUIMenu::ParameterVoice:
+		return pSynthesizer->GetVoiceParameter (pInfo->Parameter, CMiniDexed::NoOP, ucTG);
+		break;
+	case CUIMenu::ParameterOP:
+		return pSynthesizer->GetVoiceParameter (pInfo->Parameter, ucOP, ucTG);
+		break;
+	default:
+		return 0;
+		break;
+	}
+}
+
+static std::string GetParameterValueStr (CMiniDexed *pSynthesizer, CUIMenu::TCParameterInfo *pInfo, uint8_t ucOP, uint8_t ucTG)
+{
+	if (pInfo->Type == CUIMenu::ParameterNone)
+		return "...";
+	int value = GetParameterValue (pSynthesizer, pInfo, ucOP, ucTG);
+	if (pInfo->ToString)
+		return pInfo->ToString (value, 0);
+	return std::to_string (value);
+}
+
+
+void CMiniLab3DawConnection::ShowValueDisplay ()
+{
+	static const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x02, 0x60, 0x1f, 0x07, 0x01, 0x02, 0x02, 0x01, 0x00, 0x01};
+	std::string pParam = "";
+	std::string pValue = "";
+
+	for (unsigned i = 0; i < nEncoder; ++i)
+	{
+		CUIMenu::TCParameterInfo *enc = &m_pEncoders[i];
+		uint8_t ucTG = enc->TG ? enc->TG - 1 : m_ucEncoderTG ? m_ucEncoderTG - 1 : m_ucFirstTG;
+		uint8_t ucOP = enc->OP ? enc->OP - 1 : m_ucEncoderOP;
+		if (enc->OP == AllOP)
+			ucOP = 0;
+
+		std::string sValue = GetParameterValueStr (m_pSynthesizer, enc, ucOP, ucTG);
+
+		if (i < 4)
+			pParam = pParam + sValue + " ";
+		else
+			pValue = pValue + sValue + " ";
+	}
+
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 18, false, false, "", pParam.c_str(), pValue.c_str(), false, false, false);
+}
+
+void CMiniLab3DawConnection::SetPadColor (TBankID BankID, TPadID PadID, u8 state)
+{
+	SetPadColor (BankID, PadID, padColors[PadID], state);
+}
+
+void CMiniLab3DawConnection::SetPadColor (TBankID BankID, TPadID PadID, u8 state, u8 state2)
+{
+	SetPadColor (BankID, PadID, state2 ? altPadColors[PadID] : padColors[PadID], state);
+}
+
+static CColor darken(CColor color, u8 enabled)
+{
+	if (!enabled)
+	{
+		color.r /= 32;
+		color.g /= 32;
+		color.b /= 32;
+	}
+
+	return color;
+}
+
+void CMiniLab3DawConnection::SetPadColor (TBankID BankID, TPadID PadID, CColor color, u8 state)
+{
+	SetPadColor (BankID, PadID, darken (color, state));
+}
+
+void CMiniLab3DawConnection::SetPadColor (TBankID BankID, TPadID PadID, CColor color)
+{
+	if (BankID == BankA && m_PadColorCache[PadID] == color)
+		return;
+
+	const uint8_t pSetPadColor[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x02, 0x16, (uint8_t)(PadID + BankID), color.r, color.g, color.b, 0xF7};
+	m_pKeyboard->Send (pSetPadColor, sizeof pSetPadColor, 0);
+
+	if (BankID == BankA)
+		m_PadColorCache[PadID] = color;
+}
+
+void CMiniLab3DawConnection::UpdateEncoder (uint8_t ucEncID, uint8_t ucValue)
+{
+	uint8_t pUpdateEncoder[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x21, 0x10, 0x00, ucEncID+=7, 0x00, ucValue, 0xF7};
+	m_pKeyboard->Send (pUpdateEncoder, sizeof pUpdateEncoder, 0);
+}
+
+void CMiniLab3DawConnection::UpdateTGColors ()
+{
+	bool need_update = false;
+	CColor colors[8];
+	uint8_t numTG = std::min(m_pConfig->GetToneGenerators(), 8u);
+
+	for (unsigned i = 0; i < numTG; ++i)
+	{
+		u8 ch = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIChannel, i);
+		u8 enabled = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i);
+
+		colors[i] = darken (chColors[ch], enabled);
+
+		if (m_TGColorCache[i] != colors[i])
+			need_update = true;
+	}
+
+	if (!need_update)
+		return;
+
+	for (unsigned i = 0; i < numTG; ++i)
+	{
+		SetPadColor (BankB, (TPadID)i, colors[i]);
+		m_TGColorCache[i] = colors[i];
+	}
+}
+
+void CMiniLab3DawConnection::UpdateMonoColor ()
+{
+	SetPadColor (BankA, MonoPad, m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMonoMode, m_ucFirstTG));
+}
+
+void CMiniLab3DawConnection::UpdatePortamentoColor ()
+{
+	u8 mode = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoMode, m_ucFirstTG);
+	u8 mode2 = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoGlissando, m_ucFirstTG);
+	SetPadColor (BankA, PortamentoPad, mode, mode2);
+}
+
+void CMiniLab3DawConnection::UpdateATColor (u8 ucAT)
+{
+	u8 c = ucAT ?: 1;
+	SetPadColor (BankA, ATPad, CColor {c, c, c});
+}
+
+void CMiniLab3DawConnection::UpdateEncoders ()
+{
+	bool need_update = false;
+	u8 values[nEncoder];
+
+	if (m_bDisableEncoderUpdate)
+		return;
+
+	for (unsigned i = 0; i < nEncoder; ++i)
+	{
+		CUIMenu::TCParameterInfo *enc = &m_pEncoders[i];
+		u8 ucTG = enc->TG ? enc->TG - 1 : m_ucEncoderTG ? m_ucEncoderTG - 1 : m_ucFirstTG;
+		u8 ucOP = enc->OP ? enc->OP - 1 : m_ucEncoderOP;
+		if (enc->OP == AllOP)
+			ucOP = 0;
+		int value;
+
+		switch (enc->Type)
+		{
+		case CUIMenu::ParameterGlobal:
+			value = m_pSynthesizer->GetParameter (static_cast<CMiniDexed::TParameter>(enc->Parameter));
+			break;
+		case CUIMenu::ParameterTG:
+			value = m_pSynthesizer->GetTGParameter (static_cast<CMiniDexed::TTGParameter>(enc->Parameter), ucTG);
+			break;
+		case CUIMenu::ParameterVoice:
+			value = m_pSynthesizer->GetVoiceParameter (enc->Parameter, CMiniDexed::NoOP, ucTG);
+			break;
+		case CUIMenu::ParameterOP:
+			value = m_pSynthesizer->GetVoiceParameter (enc->Parameter, ucOP, ucTG);
+			break;
+		default:
+			continue;
+		}
+		values[i] = mapfloatr (value, enc->Min, enc->Max, 0, 127);
+		if (values[i] != m_EncoderCache[i])
+			need_update = true;
+	}
+
+	if (!need_update)
+		return;
+
+	for (unsigned i = 0; i < nEncoder; ++i)
+	{
+		UpdateEncoder (i, values[i]);
+		m_EncoderCache[i] = values[i];
+	}
+}
+
+void CMiniLab3DawConnection::UpdateChanGroups ()
+{
+	memset (m_ChanGroups, CMIDIDevice::Disabled, sizeof m_ChanGroups);
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		int channel = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIChannel, i);
+
+		if (channel == CMIDIDevice::ChannelUnknown || channel == CMIDIDevice::Disabled)
+			continue;
+
+		if (channel == CMIDIDevice::OmniMode)
+			channel = 0;
+
+		for (unsigned i = 0; i < sizeof m_ChanGroups; ++i)
+		{
+			if (m_ChanGroups[i] == channel)
+				break;
+
+			if (m_ChanGroups[i] == CMIDIDevice::Disabled) {
+				m_ChanGroups[i] = channel;
+				break;
+			}
+		}
+	}
+}
+
+void CMiniLab3DawConnection::UpdateState ()
+{
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i)) {
+			u8 ucChannel = m_pKeyboard->GetChannel (i);
+
+			if (ucChannel == CMIDIDevice::ChannelUnknown || ucChannel == CMIDIDevice::Disabled)
+				continue;
+
+			if (ucChannel == CMIDIDevice::OmniMode)
+				ucChannel = 0;
+
+			for (TMIDIRoute *r = m_pRouteMap; r->ucSCable != 0xFF; r++)
+					r->ucDCh = ucChannel;
+
+			m_ucFirstTG = i;
+
+			break;
+		}
+
+	UpdateEncoders ();
+
+	UpdateMonoColor ();
+	// TODO change the MIDIRouteMap's value also
+	UpdatePortamentoColor ();
+
+	UpdateTGColors ();
+
+	UpdateChanGroups ();
+}
+
+void CMiniLab3DawConnection::UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+	m_encoderPageType = Type;
+	m_ucEncoderOP = ucOP;
+	m_ucEncoderTG = ucTG;
+
+	switch (Type)
+	{
+	case CUIMenu::PageMain:
+		m_ucEncoderPage = constrain (ucPage, 0, (s8)ARRAY_LENGTH (m_pMainEncoders) - 1);
+		m_pEncoders = m_pMainEncoders[m_ucEncoderPage];
+		m_ucEncoderTG = 0; // 0 -> first active TG
+		break;
+	case CUIMenu::PageTG:
+		m_ucEncoderPage = constrain (ucPage, 0, (s8)ARRAY_LENGTH (m_pTGEncoders) - 1);
+		m_pEncoders = m_pTGEncoders[m_ucEncoderPage];
+		break;
+	//case CUIMenu::PageEffect:
+	//	m_ucEncoderPage = constrain (ucPage, 0, (s8)ARRAY_LENGTH (m_pEffectEncoders) - 1);
+	//	m_pEncoders = m_pEffectEncoders[m_ucEncoderPage];
+	//	break;
+	case CUIMenu::PageVoice:
+		m_ucEncoderPage = constrain (ucPage, 0, (s8)ARRAY_LENGTH (m_pVoiceEncoders) - 1);
+		m_pEncoders = m_pVoiceEncoders[m_ucEncoderPage];
+		break;
+	case CUIMenu::PageOP:
+		m_ucEncoderPage = constrain (ucPage, 0, (s8)ARRAY_LENGTH (m_pOPEncoders) - 1);
+		m_pEncoders = m_pOPEncoders[m_ucEncoderPage];
+		break;
+	default:
+		assert (false);
+	}
+
+	UpdateState ();
+}
+
+void CMiniLab3DawConnection::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	unsigned nDisplayUpdateDelay = nDefaultDisplayUpdateDelay;
+	switch (ucType)
+	{
+	case MIDI_CONTROL_CHANGE:
+		ArturiaShowNewCCValue (m_pKeyboard, m_pEncoder, ucChannel, ucP1, ucP2);
+
+		switch (ucP1)
+		{
+		case MIDI_CC_PORTAMENTO:
+			UpdatePortamentoColor ();
+			break;
+		case MIDI_CC_SOSTENUTO:
+			SetPadColor (BankA, SostenutoPad, ucP2);
+			break;
+		case MIDI_CC_HOLD2:
+			SetPadColor (BankA, HoldPad, ucP2);
+			break;
+		case MIDI_CC_SUSTAIN:
+			SetPadColor (BankA, SustainPad, ucP2);
+			break;
+		case MIDI_CC_ALL_SOUND_OFF:
+			SetPadColor (BankA, SoundOffPad, ucP2);
+			break;
+		}
+		break;
+	case MIDI_DAW_CHANGE:
+		switch (m_DisplayState)
+		{
+		case DisplayMenu:
+			HandleMenuEvents (m_pUI, ucP1);
+			break;
+		case DisplayEncoder:
+			switch (ucP1)
+			{
+			case MIDI_DAW_MENU_PREV:
+				UpdateMenu (m_encoderPageType, m_ucEncoderPage - 1, m_ucEncoderOP, m_ucEncoderTG);
+				ShowEncoderDisplay ();
+				break;
+			case MIDI_DAW_MENU_NEXT:
+				UpdateMenu (m_encoderPageType, m_ucEncoderPage + 1, m_ucEncoderOP, m_ucEncoderTG);
+				ShowEncoderDisplay ();
+				break;
+			case MIDI_DAW_ENC_VALUES_TOGGLE:
+				m_DisplayState = DisplayValues;
+				UpdateDisplay ();
+				break;
+			}
+			break;
+		case DisplayValues:
+			switch (ucP1)
+			{
+			case MIDI_DAW_MENU_PREV:
+				UpdateMenu (m_encoderPageType, m_ucEncoderPage - 1, m_ucEncoderOP, m_ucEncoderTG);
+				ShowEncoderDisplay ();
+				nDisplayUpdateDelay = 500;
+				break;
+			case MIDI_DAW_MENU_NEXT:
+				UpdateMenu (m_encoderPageType, m_ucEncoderPage + 1, m_ucEncoderOP, m_ucEncoderTG);
+				ShowEncoderDisplay ();
+				nDisplayUpdateDelay = 500;
+				break;
+			case MIDI_DAW_ENC_VALUES_TOGGLE:
+				m_DisplayState = DisplayEncoder;
+				UpdateDisplay ();
+				break;
+			}
+			break;
+		}
+
+		switch (ucP1)
+		{
+		case MIDI_DAW_VOICE:
+			SetVoice (ucChannel, ucP2);
+			break;
+		case MIDI_DAW_TOGGLE_MONO:
+			ToggleMonoMode (ucChannel);
+			break;
+		case MIDI_DAW_TOGGLE_PORTA_GLISS:
+			TogglePortamentoGlisssando (ucChannel);
+			break;
+		case MIDI_DAW_TOGGLE_TG:
+			ToggleTG (ucP2);
+			break;
+		case MIDI_DAW_SELECT_TG:
+			SelectTG (ucP2);
+			break;
+		case MIDI_DAW_SELECT_CHAN_TG:
+			SelectChanTG (ucP2);
+			break;
+		case MIDI_DAW_DISPLAY_MODE_TOGGLE:
+			m_DisplayState = m_DisplayState != DisplayMenu ? DisplayMenu : DisplayEncoder;
+			UpdateDisplay ();
+			break;
+		case MIDI_DAW_ENC_0:
+		case MIDI_DAW_ENC_1:
+		case MIDI_DAW_ENC_2:
+		case MIDI_DAW_ENC_3:
+		case MIDI_DAW_ENC_4:
+		case MIDI_DAW_ENC_5:
+		case MIDI_DAW_ENC_6:
+		case MIDI_DAW_ENC_7:
+			SetEncoder (ucChannel, ucP1 - MIDI_DAW_ENC_0, ucP2);
+			break;
+		case MIDI_DAW_FADER_0:
+		case MIDI_DAW_FADER_1:
+		case MIDI_DAW_FADER_2:
+		case MIDI_DAW_FADER_3:
+			SetEncoder (ucChannel, ucP1 - MIDI_DAW_FADER_0 + 8, ucP2);
+			break;
+		}
+		break;
+	case MIDI_CHANNEL_AFTERTOUCH:
+		SetChannelAT (ucP1);
+		break;
+	}
+	QueueUpdateDisplay (nDisplayUpdateDelay);
+}
+
+void CMiniLab3DawConnection::SetChannelAT (u8 ucValue)
+{
+	char line2[LINELEN];
+	snprintf(line2, LINELEN, "%d", ucValue);
+
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, ucValue, "Channel AT", line2);
+	
+	UpdateATColor (ucValue);
+}
+
+void CMiniLab3DawConnection::SetVoice (u8 ucChannel, u8 ucVoice)
+{
+	std::string line2;
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 ||
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->ProgramChange (ucVoice, i);
+		if (line2.length() == 0) {
+			std::string sVoiceName = m_pSynthesizer->GetVoiceName (i);
+			if (sVoiceName.length() > 0)
+				line2 = std::to_string (ucVoice + 1) + "=" + sVoiceName;
+		}
+	}
+	
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_KNOB, ucVoice, "Voice", line2.c_str());
+}
+
+void CMiniLab3DawConnection::SetEncoder (u8 ucChannel, u8 ucEncID, u8 ucValue)
+{
+	char line1[LINELEN];
+	char line2[LINELEN];
+
+	CUIMenu::TCParameterInfo *encoder = &m_pEncoders[ucEncID];
+
+	if (encoder->Type == CUIMenu::ParameterNone)
+		return;
+
+	int value = mapfloatr (ucValue, 0, 127, encoder->Min, encoder->Max);
+	u8 ucOP = encoder->OP ? encoder->OP - 1 : m_ucEncoderOP;
+
+	// If we update the encoders during setup, we will get rounding problems, so disable it (not for faders)
+	if (ucEncID < nEncoder)
+		m_bDisableEncoderUpdate = true;
+
+	u8 setted = false;
+
+	if (encoder->Type == CUIMenu::ParameterGlobal)
+	{
+		m_pSynthesizer->SetParameter (static_cast<CMiniDexed::TParameter>(encoder->Parameter), value);
+		setted = true;
+	}
+	else
+		for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+		{
+			if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0)
+				continue;
+
+			if (m_ucEncoderTG && m_ucEncoderTG - 1u != i)
+				continue;
+
+			if (m_ucEncoderTG == 0 && !encoder->ChG && !encoder->TG &&
+				m_pKeyboard->GetChannel (i) != ucChannel &&
+				m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode)
+				continue;
+
+			if (encoder->ChG)
+			{
+				if (m_ChanGroups[encoder->ChG - 1u] == CMIDIDevice::Disabled)
+					continue;
+
+				if (m_pKeyboard->GetChannel (i) != m_ChanGroups[encoder->ChG - 1u] &&
+					m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode)
+				continue;
+			}
+
+			if (encoder->TG && i != encoder->TG - 1u)
+				continue;
+
+			switch (encoder->Type)
+			{
+			case CUIMenu::ParameterTG:
+				// TODO: move this check into CMiniDexed?
+				if (static_cast<CMiniDexed::TTGParameter>(encoder->Parameter) == CMiniDexed::TGParameterPortamentoTime &&
+					!m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxPortamento, i))
+					continue;
+
+				m_pSynthesizer->SetTGParameter (static_cast<CMiniDexed::TTGParameter>(encoder->Parameter), value, i);
+				break;
+			case CUIMenu::ParameterVoice:
+				m_pSynthesizer->SetVoiceParameter (encoder->Parameter, value, CMiniDexed::NoOP, i);
+				break;
+			case CUIMenu::ParameterOP:
+				for (unsigned j = 0; j < 6; ++j)
+				{
+					if (encoder->OP != AllOP && j != ucOP)
+						continue;
+
+					m_pSynthesizer->SetVoiceParameter (encoder->Parameter, value, j, i);
+				}
+				break;
+			default:
+				break;
+			}
+			setted = true;
+		}
+	
+	m_bDisableEncoderUpdate = false;
+
+	if (!setted)
+		return;
+
+	if (encoder->ChG)
+		snprintf(line1, LINELEN, "Ch %d %s", m_ChanGroups[encoder->ChG - 1u] + 1, encoder->Name);
+	else if (encoder->TG)
+		snprintf(line1, LINELEN, "TG%d %s", encoder->TG, encoder->Name);
+	else
+		snprintf(line1, LINELEN, "%s", encoder->Name);
+
+	if (encoder->ToString)
+		snprintf(line2, LINELEN, "%s", encoder->ToString(value, 0).c_str());
+	else
+		snprintf(line2, LINELEN, "%d", value);
+
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, ucEncID < nEncoder ? CT_KNOB : CT_FADER, ucValue, line1, line2);
+}
+
+void CMiniLab3DawConnection::ToggleMonoMode (u8 ucChannel)
+{
+	u8 ucValue = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMonoMode, m_ucFirstTG) ? 0x00 : 0x7F;
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 ||
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->setMonoMode (ucValue, i);
+	}
+
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, ucValue, "Mono Mode", ucValue > 64 ? "On" : "Off");
+	UpdateMonoColor ();
+}
+
+void CMiniLab3DawConnection::TogglePortamentoGlisssando (u8 ucChannel)
+{
+	u8 ucValue = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoGlissando, m_ucFirstTG) ? 0x00 : 0x7F;
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 &&
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->setPortamentoGlissando (ucValue, i);
+	}
+
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, ucValue, "Porta Gliss", ucValue > 64 ? "On" : "Off");
+	UpdatePortamentoColor ();
+}
+
+void CMiniLab3DawConnection::ToggleTG (u8 ucTG)
+{
+	char line1[LINELEN];
+
+	u8 value = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, ucTG) ? 0x00 : 0x7F;
+
+	m_pSynthesizer->setEnabled (value, ucTG);
+	m_pSynthesizer->panic (value, ucTG);
+
+	snprintf(line1, LINELEN, "TG %d", ucTG + 1);
+	ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, value, line1, value > 64 ? "On" : "Off");
+}
+
+void CMiniLab3DawConnection::SelectTG (u8 ucTG)
+{
+	char line1[LINELEN];
+
+	u8 enabledOne = true;
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (i == ucTG)
+			continue;
+
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i)) {
+			enabledOne = false;
+			break;
+		}
+	}
+
+	if (enabledOne) {
+		for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i) {
+			m_pSynthesizer->setEnabled (true, i);
+		}
+		ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, 0x7F, "TG All", "On");
+	} else {
+		for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i) {
+			if (i == ucTG) {
+				m_pSynthesizer->setEnabled (true, i);
+			} else {
+				m_pSynthesizer->setEnabled (false, i);
+				m_pSynthesizer->panic (false, i);
+			}
+		}
+		snprintf(line1, LINELEN, "TG %d", ucTG + 1);
+		ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, 0x7F, line1, "Selected");
+	}
+}
+
+
+void CMiniLab3DawConnection::SelectChanTG (u8 ucTG)
+{
+	char line1[LINELEN];
+
+	u8 enabled = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, ucTG);
+	u8 channel = m_pKeyboard->GetChannel (ucTG);
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i) {
+		if (m_pKeyboard->GetChannel (i) == channel) {
+			if (enabled) {
+				m_pSynthesizer->setEnabled (false, i);
+				m_pSynthesizer->panic (false, i);
+			} else {
+				m_pSynthesizer->setEnabled (true, i);
+			}
+		}
+	}
+
+	snprintf(line1, LINELEN, "TGs on Ch %s", to_midi_channel(channel).c_str());
+
+	// this doesn't work well with Minilab 3 firmware 1.2.0
+	// ArturiaDisplayInfoWrite (m_pKeyboard, m_pEncoder, CT_PAD, 0x7F, line1, enabled ? "Off" : "On");
+
+	DisplayWriteSimple (line1, "", enabled ? "Off" : "On");
+}
+
+class CKeyLabEs3DawConnection : public CDAWConnection
+{
+public:
+	CKeyLabEs3DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI);
+	void DisplayWrite ( const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp) override;
+	void UpdateState () override;
+	void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG) override;
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) override;
+private:
+	void UpdateEncoder (uint8_t ucEncID, uint8_t ucValue);
+
+	CMiniDexed *m_pSynthesizer;
+	CMIDIKeyboard *m_pKeyboard;
+	CConfig *m_pConfig;
+	CUserInterface *m_pUI;
+
+	const uint8_t m_pEncoder[3] = {0x04, 0x01, 0x60};
+	TMIDIRoute m_pRouteMap[26] = {
+		{0, 0, MIDI_CONTROL_CHANGE, 117, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Main knob click
+		{0, 0, MIDI_CONTROL_CHANGE, 117, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_SELECT, 0, .bGroup=true},
+		{0, 0, MIDI_CONTROL_CHANGE, 117, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_BACK, 0, .bGroup=true},
+		{0, 0, MIDI_CONTROL_CHANGE, 116, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_PREV, 0xFF, .bGroup=true, .bGroupHold=true}, // Main knob click + rotate
+		{0, 0, MIDI_CONTROL_CHANGE, 116, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_NEXT, 0xFF, .bGroup=true, .bGroupHold=true},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 44, 0x7F, .bSkip=true}, // Home
+		{0, 0, MIDI_CONTROL_CHANGE, 44, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_HOME, 0},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 116, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PREV, 0xFF}, // Main knob
+		{0, 0, MIDI_CONTROL_CHANGE, 116, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_NEXT, 0xFF},
+
+		{0, 0, MIDI_CONTROL_CHANGE, 105, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader1
+		{0, 0, MIDI_CONTROL_CHANGE, 106, 0xFF, 1, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader2
+		{0, 0, MIDI_CONTROL_CHANGE, 107, 0xFF, 2, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader3
+		{0, 0, MIDI_CONTROL_CHANGE, 108, 0xFF, 3, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader4
+		{0, 0, MIDI_CONTROL_CHANGE, 109, 0xFF, 4, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader5
+		{0, 0, MIDI_CONTROL_CHANGE, 110, 0xFF, 5, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader6
+		{0, 0, MIDI_CONTROL_CHANGE, 111, 0xFF, 6, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader7
+		{0, 0, MIDI_CONTROL_CHANGE, 112, 0xFF, 7, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader8
+		{0, 0, MIDI_CONTROL_CHANGE, 113, 0xFF, 8, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader9
+
+		{0, 0, MIDI_CONTROL_CHANGE, 96, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_FREQUENCY_CUTOFF, 0xFF}, // Knob1
+		{0, 0, MIDI_CONTROL_CHANGE, 97, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_RESONANCE, 0xFF}, // Knob2
+		{0, 0, MIDI_CONTROL_CHANGE, 98, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_EFFECT1_SEND, 0xFF}, // Knob3
+		{0, 0, MIDI_CONTROL_CHANGE, 99, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_EFFECT2_SEND, 0xFF}, // Knob4
+		{0, 0, MIDI_CONTROL_CHANGE, 100, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_DETUNE_LEVEL, 0xFF}, // Knob5
+		{0, 0, MIDI_CONTROL_CHANGE, 101, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob6
+		{0, 0, MIDI_CONTROL_CHANGE, 102, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PORTAMENTO_TIME, 0xFF}, // Knob7
+		// {0, 0, MIDI_CONTROL_CHANGE, 103, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob8
+		// {0, 0, MIDI_CONTROL_CHANGE, 104, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob9
+		{0xFF}, // Sentinel
+	};
+};
+
+CKeyLabEs3DawConnection::CKeyLabEs3DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI)
+	:m_pSynthesizer (pSynthesizer), m_pKeyboard (pKeyboard), m_pConfig (pConfig), m_pUI (pUI)
+{
+	static const uint8_t pInit[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x40, 0x6A, 0x21, 0xF7};
+
+	m_pKeyboard->SetRouteMap (m_pRouteMap);
+
+	m_pKeyboard->Send (pInit, sizeof pInit, 0);
+	DisplayWrite ("DreamDexed", "", "On KeyLab 3 Essential", 0, 0);
+
+	UpdateState ();
+}
+
+void CKeyLabEs3DawConnection::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp)
+{
+	static const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x01, 0x60, 0x12, 0x01};
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 18, true, true, pMenu, pParam, pValue, bArrowDown, bArrowUp, true);
+}
+
+void CKeyLabEs3DawConnection::UpdateEncoder (uint8_t ucEncID, uint8_t ucValue)
+{
+	uint8_t pUpdateEncoder[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x0F, 0x40, ucEncID += 3, ucValue, 0xF7};
+	m_pKeyboard->Send (pUpdateEncoder, sizeof pUpdateEncoder, 0);
+} 
+
+void CKeyLabEs3DawConnection::UpdateState ()
+{
+	UpdateEncoder (0, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterCutoff, 0), 0, 99, 0, 127));
+	UpdateEncoder (1, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterResonance, 0), 0, 99, 0, 127));
+	UpdateEncoder (2, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterFX1Send, 0), 0, 99, 0, 127));
+	UpdateEncoder (3, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterFX2Send, 0), 0, 99, 0, 127));
+	UpdateEncoder (4, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMasterTune, 0), -99, 99, 1, 127));
+	UpdateEncoder (5, m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPan, 0));
+	UpdateEncoder (6, mapfloatr (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoTime, 0), 0, 99, 0, 127));
+}
+
+void CKeyLabEs3DawConnection::UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+
+}
+
+void CKeyLabEs3DawConnection::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	switch (ucType)
+	{
+	case MIDI_CONTROL_CHANGE:
+		ArturiaShowNewCCValue (m_pKeyboard, m_pEncoder, ucChannel, ucP1, ucP2);
+		break;
+	case MIDI_DAW_CHANGE:
+		HandleMenuEvents (m_pUI, ucP1);
+		break;
+	}
+}
+
+class CKeyLab2DawConnection : public CDAWConnection
+{
+public:
+	CKeyLab2DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI);
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp) override;
+	void UpdateState () override;
+	void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG) override;
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) override;
+private:
+	using TToString = CUIMenu::TToString;
+	struct TButton {
+		uint8_t sysexID;
+		const char* name;
+		uint8_t last_value;
+	};
+	struct TRGBButton {
+		uint8_t sysexID;
+		CColor last_color = invalidColor;
+	};
+
+	bool m_bDisableStateUpdate = false;
+
+	TButton m_MonoButton = {0x60, "Mono mode"};
+	TButton m_PortamentoButton = {0x61, "Portamento"};
+	TButton m_SostenutoButton = {0x62, "Sostenuto"};
+	TButton m_SustainButton = {0x63, "Sustain"};
+	TButton m_Hold2Button = {0x64, "Hold"};
+
+	TRGBButton m_SelButtons[8] = {
+		{0x22}, {0x23}, {0x24}, {0x25}, {0x26}, {0x27}, {0x28}, {0x29},
+	};
+
+	static void s_UpdateDisplay (TKernelTimerHandle hTimer, void *pParam, void *pContext);
+	void QueueUpdateDisplay (unsigned msec);
+	void UpdateDisplay ();
+	void ShowNewValue (const char* name, u8 ucP2, TToString *ToString = NULL);
+
+	void SetButtonColor (TRGBButton &button, CColor color);
+
+	void SetButtonIntensity (TButton &button, uint8_t intensity);
+	void SetButtonLight (TButton &button, u8 state);
+	void SetButtonLight (TButton &button, u8 state, u8 state2);
+
+	void UpdateVolumeFaders ();
+	void UpdateTGColors ();
+	void UpdateMonoColor ();
+	void UpdatePortamentoColor ();
+	void SetMasterVolume (u8 ucValue);
+	int SetParameter (u8 ucChannel, u8 ucDiffValue, CMiniDexed::TParameter parameter);
+	int SetTGParameter (u8 ucChannel, u8 ucDiffValue, CMiniDexed::TTGParameter parameter);
+
+	void ToggleMonoMode (u8 ucChannel);
+	void TogglePortamentoGlisssando (u8 ucChannel);
+
+	void ToggleTG (u8 ucTG);
+	void SelectTG (u8 ucTG);
+
+
+	CMiniDexed *m_pSynthesizer;
+	CMIDIKeyboard *m_pKeyboard;
+	CConfig *m_pConfig;
+	CUserInterface *m_pUI;
+
+	TKernelTimerHandle m_DisplayTimer = 0;
+
+	u8 m_ucFirstTG = 0;
+
+	TMIDIRoute m_pRouteMap[58] = {
+		{1, 0, MIDI_PITCH_BEND, 0xFF, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader1
+		{1, 1, MIDI_PITCH_BEND, 0xFF, 0xFF, 1, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader2
+		{1, 2, MIDI_PITCH_BEND, 0xFF, 0xFF, 2, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader3
+		{1, 3, MIDI_PITCH_BEND, 0xFF, 0xFF, 3, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader4
+		{1, 4, MIDI_PITCH_BEND, 0xFF, 0xFF, 4, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader5
+		{1, 5, MIDI_PITCH_BEND, 0xFF, 0xFF, 5, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader6
+		{1, 6, MIDI_PITCH_BEND, 0xFF, 0xFF, 6, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader7
+		{1, 7, MIDI_PITCH_BEND, 0xFF, 0xFF, 7, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader8
+		{1, 8, MIDI_PITCH_BEND, 0xFF, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_MASTER_VOLUME, 0xFF}, // Fader9
+
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Main knob click
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_SELECT, 0, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_BACK, 0, .bGroup=true},
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_PREV, 0xFF, .bGroup=true, .bGroupHold=true}, // Main knob click + rotate
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_NEXT, 0xFF, .bGroup=true, .bGroupHold=true},
+
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PREV, 0xFF}, // Main knob
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_NEXT, 0xFF},
+
+		//{1, 0, MIDI_NOTE_ON, 0x31, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0}, // Next
+		//{1, 0, MIDI_NOTE_ON, 0x30, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0}, // Prev
+		//{1, 0, MIDI_NOTE_ON, 0x21, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0}, // Bank?
+
+		{1, 0, MIDI_NOTE_ON, 0x18, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select1
+		{1, 0, MIDI_NOTE_ON, 0x18, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x18, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 0, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x19, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select2
+		{1, 0, MIDI_NOTE_ON, 0x19, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 1, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x19, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 1, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1a, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select3
+		{1, 0, MIDI_NOTE_ON, 0x1a, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 2, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1a, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 2, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1b, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select4
+		{1, 0, MIDI_NOTE_ON, 0x1b, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 3, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1b, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 3, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1c, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select5
+		{1, 0, MIDI_NOTE_ON, 0x1c, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 4, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1c, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 4, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1d, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select6
+		{1, 0, MIDI_NOTE_ON, 0x1d, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 5, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1d, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 5, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1e, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select7
+		{1, 0, MIDI_NOTE_ON, 0x1e, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 6, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1e, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 6, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, 0x1f, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Select8
+		{1, 0, MIDI_NOTE_ON, 0x1f, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 7, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x1f, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_SELECT_TG, 7, .bGroup=true},
+
+		//{1, 0, MIDI_NOTE_ON, 0x33, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_TG, 0}, // Select9?
+
+		{1, 0, MIDI_NOTE_ON, TMIDIRoute::Betw08n15, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_MONO, 0x7f}, // Solo
+
+		{1, 0, MIDI_NOTE_ON, TMIDIRoute::Betw16n23, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Mute
+		{1, 0, MIDI_NOTE_ON, TMIDIRoute::Betw16n23, 0x00, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PORTAMENTO, 0x7F, .bToggle=true, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, TMIDIRoute::Betw16n23, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_TOGGLE_PORTA_GLISS, 0x7F, .bGroup=true},
+
+		{1, 0, MIDI_NOTE_ON, TMIDIRoute::Betw00n07, 0x00, 0, MIDI_CONTROL_CHANGE, MIDI_CC_SOSTENUTO, 0x7F, .bToggle=true}, // Record
+
+		{1, 0, MIDI_NOTE_ON, 0x4a, 0x00, 0, MIDI_CONTROL_CHANGE, MIDI_CC_SUSTAIN, 0x7F, .bToggle=true}, // Read
+
+		{1, 0, MIDI_NOTE_ON, 0x4b, 0x00, 0, MIDI_CONTROL_CHANGE, MIDI_CC_HOLD2, 0x7F, .bToggle=true}, // Write
+
+		{1, 0, MIDI_CONTROL_CHANGE, 16, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_0, 0xFF}, // Knob1
+		{1, 0, MIDI_CONTROL_CHANGE, 17, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_1, 0xFF}, // Knob2
+		{1, 0, MIDI_CONTROL_CHANGE, 18, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_2, 0xFF}, // Knob3
+		{1, 0, MIDI_CONTROL_CHANGE, 19, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_3, 0xFF}, // Knob4
+		{1, 0, MIDI_CONTROL_CHANGE, 20, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_4, 0xFF}, // Knob5
+		{1, 0, MIDI_CONTROL_CHANGE, 21, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_5, 0xFF}, // Knob6
+		{1, 0, MIDI_CONTROL_CHANGE, 22, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_6, 0xFF}, // Knob7
+		{1, 0, MIDI_CONTROL_CHANGE, 23, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_7, 0xFF}, // Knob8
+		{1, 0, MIDI_CONTROL_CHANGE, 24, 0xFF, 0, MIDI_DAW_CHANGE, MIDI_DAW_ENC_8, 0xFF}, // Knob9
+		{1, 0xFF, 0xFF, 0xFF, 0xFF, .bSkip = true}, // skip other messages on DAW cable
+		{0xFF}, // Sentinel
+	};
+};
+
+/*
+https://github.com/bitwig/bitwig-extensions/blob/da7d70e73cc055475d63ac6c7de17e69f89f4993/src/main/java/com/bitwig/extensions/controllers/arturia/keylab/mk2/ButtonId.java
+SOLO(0x60, 0x08),
+MUTE(0x61, 0x10),
+RECORD_ARM(0x62, 0x00),
+READ(0x63, 0x38), // 0x38 -> 0x4a
+WRITE(0x64, 0x39), // 0x39 -> 0x4b
+
+SAVE(0x65,0x4A),
+PUNCH_IN(0x66, 0x57),
+PUNCH_OUT(0x67, 0x58),
+METRO(0x68, 0x59),
+UNDO(0x69, 0x51),
+
+
+NEXT(0x1F, 0x31),
+PREVIOUS(0x20, 0x30),
+BANK(0x21, 0x21),
+SELECT1(0x22, 0x18),
+SELECT2(0x23, 0x19),
+SELECT3(0x24, 0x1A),
+SELECT4(0x25, 0x1B),
+SELECT5(0x26, 0x1C),
+SELECT6(0x27, 0x1D),
+SELECT7(0x28, 0x1E),
+SELECT8(0x29, 0x1F),
+SELECT_MULTI(0x2A, 0x33);
+*/
+
+CKeyLab2DawConnection::CKeyLab2DawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI)
+	:m_pSynthesizer (pSynthesizer), m_pKeyboard (pKeyboard), m_pConfig (pConfig), m_pUI (pUI)
+{
+	static const uint8_t pInit[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x40, 0x52, 0x00, 0xF7};
+	m_pKeyboard->SetRouteMap (m_pRouteMap);
+
+	m_pKeyboard->Send (pInit, sizeof pInit, 0);
+	DisplayWrite ("DreamDexed", "", "On KeyLab 2", 0, 0);
+
+	SetButtonLight (m_SostenutoButton, 0);
+	SetButtonLight (m_SustainButton, 0);
+	SetButtonLight (m_Hold2Button, 0);
+
+	UpdateState ();
+	QueueUpdateDisplay (nDefaultDisplayUpdateDelay);
+}
+
+void CKeyLab2DawConnection::SetButtonColor (TRGBButton &button, CColor color)
+{
+	const uint8_t pSetButtonColor[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x16, button.sysexID, color.r, color.g, color.b, 0xF7};
+	m_pKeyboard->Send (pSetButtonColor, sizeof pSetButtonColor, 0);
+}
+
+void CKeyLab2DawConnection::SetButtonIntensity (TButton &button, uint8_t intensity)
+{
+	if (button.last_value == intensity)
+		return;
+
+	const uint8_t pSetButtonIntensity[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x10, button.sysexID, intensity, 0xF7};
+	m_pKeyboard->Send (pSetButtonIntensity, sizeof pSetButtonIntensity, 0);
+
+	button.last_value = intensity;
+}
+
+void CKeyLab2DawConnection::SetButtonLight (TButton &button, u8 state)
+{
+	SetButtonIntensity (button, state ? 0x7F : 0x04);
+}
+
+void CKeyLab2DawConnection::SetButtonLight (TButton &button, u8 state, u8 state2)
+{
+	SetButtonIntensity (button, state ? state2 ? 0x7F : 0x3f : 0x04);
+}
+
+void CKeyLab2DawConnection::UpdateTGColors ()
+{
+	bool need_update = false;
+	CColor colors[8];
+	uint8_t numTG = std::min(m_pConfig->GetToneGenerators(), 8u);
+
+	for (unsigned i = 0; i < numTG; ++i)
+	{
+		u8 ch = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIChannel, i);
+		u8 enabled = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i);
+
+		colors[i] = chColors_kl2[ch];
+		if (!enabled)
+		{
+			colors[i].r /= 8;
+			colors[i].g /= 8;
+			colors[i].b /= 8;
+		}
+
+		if (m_SelButtons[i].last_color != colors[i])
+			need_update = true;
+	}
+
+	if (!need_update)
+		return;
+
+	for (unsigned i = 0; i < numTG; ++i)
+	{
+		SetButtonColor (m_SelButtons[i], colors[i]);
+		m_SelButtons[i].last_color = colors[i];
+	}
+}
+
+
+void CKeyLab2DawConnection::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp)
+{
+	static const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x00, 0x60, 0x01};
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 16, true, true, pMenu, pParam, pValue, bArrowDown, bArrowUp, true);
+}
+
+void CKeyLab2DawConnection::QueueUpdateDisplay (unsigned msec)
+{
+	if (m_DisplayTimer)
+		CTimer::Get ()->CancelKernelTimer (m_DisplayTimer);
+	m_DisplayTimer = CTimer::Get ()->StartKernelTimer (MSEC2HZ (msec), s_UpdateDisplay, this, NULL);
+}
+
+void CKeyLab2DawConnection::s_UpdateDisplay (TKernelTimerHandle hTimer, void *pParam, void *pContext)
+{
+	assert (pParam != NULL);
+	static_cast<CKeyLab2DawConnection*>(pParam)->UpdateDisplay ();
+}
+
+void CKeyLab2DawConnection::UpdateDisplay ()
+{
+	m_pUI->MIDIEventHandler (CUIMenu::MenuEventUpdate);
+}
+
+void CKeyLab2DawConnection::ShowNewValue (const char* name, u8 ucP2, CUIMenu::TToString *ToString)
+{
+	std::string line2 = ToString ? ToString(ucP2, 0) : std::to_string(ucP2);
+	DisplayWrite (name, "", line2.c_str(), 0, 0);
+}
+
+void CKeyLab2DawConnection::UpdateState ()
+{
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i)) {
+			u8 ucChannel = m_pKeyboard->GetChannel (i);
+
+			if (ucChannel == CMIDIDevice::ChannelUnknown || ucChannel == CMIDIDevice::Disabled)
+				continue;
+
+			if (ucChannel == CMIDIDevice::OmniMode)
+				ucChannel = 0;
+
+			for (TMIDIRoute *r = m_pRouteMap; r->ucSCable != 0xFF; r++)
+				r->ucDCh = ucChannel;
+
+			m_ucFirstTG = i;
+
+			break;
+		}
+
+	UpdateVolumeFaders ();
+
+	if (m_bDisableStateUpdate)
+		return;
+
+	UpdateTGColors ();
+	UpdateMonoColor ();
+	UpdatePortamentoColor ();
+}
+
+void CKeyLab2DawConnection::UpdateVolumeFaders ()
+{
+	u8 chan_map[8] = {
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+		CMIDIDevice::TChannel::Disabled,
+	};
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		int channel = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIChannel, i);
+
+		if (channel == CMIDIDevice::ChannelUnknown || channel == CMIDIDevice::Disabled)
+			continue;
+
+		if (channel == CMIDIDevice::OmniMode)
+			channel = 0;
+
+		for (unsigned i = 0; i < sizeof chan_map; ++i)
+		{
+			if (chan_map[i] == channel)
+				break;
+
+			if (chan_map[i] == CMIDIDevice::Disabled) {
+				chan_map[i] = channel;
+				break;
+			}
+		}
+	}
+
+	for (unsigned i = 0; i < sizeof chan_map; ++i)
+	{
+		if (chan_map[i] == CMIDIDevice::Disabled)
+			m_pRouteMap[i].bSkip = true;
+		else {
+			m_pRouteMap[i].bSkip = false;
+			m_pRouteMap[i].ucDCh = chan_map[i];
+		}
+	}
+}
+
+void CKeyLab2DawConnection::ToggleTG (u8 ucTG)
+{
+	char line1[LINELEN];
+
+	u8 value = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, ucTG) ? 0x00 : 0x7F;
+
+	m_pSynthesizer->setEnabled (value, ucTG);
+	m_pSynthesizer->panic (value, ucTG);
+
+	snprintf(line1, LINELEN, "TG %d", ucTG + 1);
+	ShowNewValue (line1, value, to_on_off);
+}
+
+void CKeyLab2DawConnection::SelectTG (u8 ucTG)
+{
+	char line1[LINELEN];
+
+	u8 enabledOne = true;
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (i == ucTG)
+			continue;
+
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i)) {
+			enabledOne = false;
+			break;
+		}
+	}
+
+	m_bDisableStateUpdate = true;
+
+	if (enabledOne) {
+		for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i) {
+			m_pSynthesizer->setEnabled (true, i);
+		}
+		ShowNewValue ("TG All", 0x7f, to_on_off);
+	} else {
+		for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i) {
+			if (i == ucTG) {
+				m_pSynthesizer->setEnabled (true, i);
+			} else {
+				m_pSynthesizer->setEnabled (false, i);
+				m_pSynthesizer->panic (false, i);
+			}
+		}
+		snprintf(line1, LINELEN, "TG %d", ucTG + 1);
+		ShowNewValue (line1, 0x7f, to_selected);
+	}
+
+	m_bDisableStateUpdate = false;
+	UpdateState ();
+}
+
+void CKeyLab2DawConnection::ToggleMonoMode (u8 ucChannel)
+{
+	u8 ucValue = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMonoMode, m_ucFirstTG) ? 0x00 : 0x7F;
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 ||
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->setMonoMode (ucValue, i);
+	}
+
+	ShowNewValue ("Mono Mode", ucValue, to_on_off);
+}
+
+void CKeyLab2DawConnection::SetMasterVolume (u8 ucValue)
+{
+	m_pSynthesizer->SetParameter (CMiniDexed::ParameterMasterVolume, ucValue);
+	ShowNewValue ("Master Volume", ucValue, to_percent);
+}
+
+int CKeyLab2DawConnection::SetParameter (u8 ucChannel, u8 ucDiffValue, CMiniDexed::TParameter parameter)
+{
+	int ucValue = m_pSynthesizer->GetParameter (parameter);
+
+	if (ucDiffValue < 64) // 1 2 3
+		ucValue += ucDiffValue;
+	else // 65 66 67
+		ucValue = std::max(0, ucValue - (ucDiffValue - 64));
+
+	m_pSynthesizer->SetParameter (parameter, ucValue);
+
+	return m_pSynthesizer->GetParameter (parameter);
+}
+
+int CKeyLab2DawConnection::SetTGParameter (u8 ucChannel, u8 ucDiffValue, CMiniDexed::TTGParameter parameter)
+{
+	int ucValue = m_pSynthesizer->GetTGParameter (parameter, m_ucFirstTG);
+
+	if (ucDiffValue < 64) // 1 2 3
+		ucValue += ucDiffValue;
+	else // 65 66 67
+		ucValue = std::max(0, ucValue - (ucDiffValue - 64));
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 &&
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->SetTGParameter (parameter, ucValue, i);
+	}
+
+	return m_pSynthesizer->GetTGParameter (parameter, m_ucFirstTG);
+}
+
+void CKeyLab2DawConnection::UpdateMonoColor ()
+{
+	SetButtonLight (m_MonoButton, m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMonoMode, m_ucFirstTG));
+}
+
+void CKeyLab2DawConnection::UpdatePortamentoColor ()
+{
+	u8 mode = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoMode, m_ucFirstTG);
+	u8 mode2 = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoGlissando, m_ucFirstTG);
+	SetButtonLight (m_PortamentoButton, mode, mode2);
+}
+
+void CKeyLab2DawConnection::TogglePortamentoGlisssando (u8 ucChannel)
+{
+	u8 ucValue = m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterPortamentoGlissando, m_ucFirstTG) ? 0x00 : 0x7F;
+
+	for (unsigned i = 0; i < m_pConfig->GetToneGenerators(); ++i)
+	{
+		if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, i) == 0 &&
+			(m_pKeyboard->GetChannel (i) != ucChannel && m_pKeyboard->GetChannel (i) != CMIDIDevice::OmniMode))
+			continue;
+		m_pSynthesizer->setPortamentoGlissando (ucValue, i);
+	}
+
+	ShowNewValue ("Porta Gliss", ucValue, to_on_off);
+	UpdatePortamentoColor ();
+}
+
+
+void CKeyLab2DawConnection::UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+}
+
+void CKeyLab2DawConnection::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	int ucValue;
+
+	switch (ucType)
+	{
+	case MIDI_CONTROL_CHANGE:
+		switch (ucP1)
+		{
+		case MIDI_CC_VOLUME:
+			char line1[LINELEN];
+			snprintf(line1, LINELEN, "Volume Ch %d", ucChannel + 1);
+			ShowNewValue (line1, ucP2, to_percent);
+			break;
+		case MIDI_CC_PORTAMENTO:
+			UpdatePortamentoColor ();
+			ShowNewValue (m_PortamentoButton.name, ucP2, to_on_off);
+			break;
+		case MIDI_CC_SOSTENUTO:
+			SetButtonLight (m_SostenutoButton, ucP2);
+			ShowNewValue (m_SostenutoButton.name, ucP2, to_on_off);
+			break;
+		case MIDI_CC_HOLD2:
+			SetButtonLight (m_Hold2Button, ucP2);
+			ShowNewValue (m_Hold2Button.name, ucP2, to_on_off);
+			break;
+		case MIDI_CC_SUSTAIN:
+			SetButtonLight (m_SustainButton, ucP2);
+			ShowNewValue (m_SustainButton.name, ucP2, to_on_off);
+			break;
+		}
+		break;
+
+	case MIDI_DAW_CHANGE:
+		HandleMenuEvents (m_pUI, ucP1);
+		
+		switch (ucP1)
+		{
+		case MIDI_DAW_TOGGLE_MONO:
+			ToggleMonoMode (ucChannel);
+			break;
+		case MIDI_DAW_TOGGLE_PORTA_GLISS:
+			TogglePortamentoGlisssando (ucChannel);
+			break;
+		case MIDI_DAW_SELECT_TG:
+			SelectTG (ucP2);
+			break;
+		case MIDI_DAW_TOGGLE_TG:
+			ToggleTG (ucP2);
+			break;
+		case MIDI_DAW_MASTER_VOLUME:
+			SetMasterVolume (ucP2);
+			break;
+		case MIDI_DAW_ENC_0:
+			ucValue = SetTGParameter(ucChannel, ucP2, CMiniDexed::TGParameterCutoff);
+			ShowNewValue ("Cutoff", ucValue, to_string);
+			break;
+		case MIDI_DAW_ENC_1:
+			ucValue = SetTGParameter(ucChannel, ucP2, CMiniDexed::TGParameterResonance);
+			ShowNewValue ("Resonance", ucValue, to_string);
+			break;
+		case MIDI_DAW_ENC_2:
+			ucValue = SetTGParameter(ucChannel, ucP2, CMiniDexed::TGParameterPortamentoTime);
+			ShowNewValue ("Portamento time", ucValue, to_string);
+			break;
+		case MIDI_DAW_ENC_5:
+			ucValue = SetParameter(ucChannel, ucP2, CMiniDexed::ParameterMixerDryLevel);
+			ShowNewValue ("Dry Level", ucValue, to_string);
+			break;
+		case MIDI_DAW_ENC_6:
+			ucValue = SetTGParameter(ucChannel, ucP2, CMiniDexed::TGParameterFX1Send);
+			ShowNewValue ("FX1Send", ucValue, to_string);
+			break;
+		case MIDI_DAW_ENC_7:
+			ucValue = SetTGParameter(ucChannel, ucP2, CMiniDexed::TGParameterFX2Send);
+			ShowNewValue ("FX2Send", ucValue, to_string);
+			break;
+		}
+		break;
+	}
+
+	QueueUpdateDisplay (nDefaultDisplayUpdateDelay);
+}
+
+class CKeyLabEsDawConnection : public CDAWConnection
+{
+public:
+	CKeyLabEsDawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI);
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp) override;
+	void UpdateState () override;
+	void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG) override;
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) override;
+private:
+	CMiniDexed *m_pSynthesizer;
+	CMIDIKeyboard *m_pKeyboard;
+	CConfig *m_pConfig;
+	CUserInterface *m_pUI;
+
+	TMIDIRoute m_pRouteMap[18] = {
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x7F, .ucTimerTarget=2, .usTimerExpire=m_pConfig->GetLongPressTimeout (), .bSkip=true}, // Main knob click
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_SELECT, 0, .bGroup=true},
+		{1, 0, MIDI_NOTE_ON, 0x54, 0x00, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_BACK, 0, .bGroup=true},
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_PREV, 0xFF, .bGroup=true, .bGroupHold=true}, // Main knob click + rotate
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PRESS_NEXT, 0xFF, .bGroup=true, .bGroupHold=true},
+
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::GtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_PREV, 0xFF}, // Main knob
+		{1, 0, MIDI_CONTROL_CHANGE, 0x3C, TMIDIRoute::LtCenter, 0, MIDI_DAW_CHANGE, MIDI_DAW_MENU_NEXT, 0xFF},
+
+		{1, 0, MIDI_PITCH_BEND, 0xFF, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader1
+		{1, 1, MIDI_PITCH_BEND, 0xFF, 0xFF, 1, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader2
+		{1, 2, MIDI_PITCH_BEND, 0xFF, 0xFF, 2, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader3
+		{1, 3, MIDI_PITCH_BEND, 0xFF, 0xFF, 3, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader4
+		{1, 4, MIDI_PITCH_BEND, 0xFF, 0xFF, 4, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader5
+		{1, 5, MIDI_PITCH_BEND, 0xFF, 0xFF, 5, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader6
+		{1, 6, MIDI_PITCH_BEND, 0xFF, 0xFF, 6, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader7
+		{1, 7, MIDI_PITCH_BEND, 0xFF, 0xFF, 7, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader8
+		{1, 8, MIDI_PITCH_BEND, 0xFF, 0xFF, 8, MIDI_CONTROL_CHANGE, MIDI_CC_VOLUME, 0xFF}, // Fader9
+		/*{0, 0, MIDI_CONTROL_CHANGE, 96, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_FREQUENCY_CUTOFF, 0xFF}, // Knob1
+		{0, 0, MIDI_CONTROL_CHANGE, 97, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_RESONANCE, 0xFF}, // Knob2
+		{0, 0, MIDI_CONTROL_CHANGE, 98, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_REVERB_LEVEL, 0xFF}, // Knob3
+		{0, 0, MIDI_CONTROL_CHANGE, 99, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_DETUNE_LEVEL, 0xFF}, // Knob4
+		{0, 0, MIDI_CONTROL_CHANGE, 100, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob5
+		{0, 0, MIDI_CONTROL_CHANGE, 101, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PORTAMENTO_TIME, 0xFF}, // Knob6
+		// {0, 0, MIDI_CONTROL_CHANGE, 102, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_DETUNE_LEVEL, 0xFF}, // Knob7
+		// {0, 0, MIDI_CONTROL_CHANGE, 103, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob8
+		// {0, 0, MIDI_CONTROL_CHANGE, 104, 0xFF, 0, MIDI_CONTROL_CHANGE, MIDI_CC_PAN_POSITION, 0xFF}, // Knob9*/
+		{1, 0xFF, 0xFF, 0xFF, 0xFF, .bSkip = true}, // skip other messages on DAW cable
+		{0xFF}, // Sentinel
+	};
+};
+
+CKeyLabEsDawConnection::CKeyLabEsDawConnection (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI)
+	:m_pSynthesizer (pSynthesizer), m_pKeyboard (pKeyboard), m_pConfig (pConfig), m_pUI (pUI)
+{
+	static const uint8_t pInit[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x02, 0x00, 0x40, 0x51, 0x00, 0xF7}; // init DAW to Mackie mode
+	m_pKeyboard->SetRouteMap (m_pRouteMap);
+
+	m_pKeyboard->Send (pInit, sizeof pInit, 0);
+	DisplayWrite ("DreamDexed", "", "On KeyLab Essential", 0, 0);
+
+	UpdateState ();
+}
+
+void CKeyLabEsDawConnection::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue, bool bArrowDown, bool bArrowUp)
+{
+	static const uint8_t pHdr[] = {0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42, 0x04, 0x00, 0x60, 0x01};
+	ArturiaDisplayWrite (m_pKeyboard, pHdr, sizeof pHdr, 16, true, true, pMenu, pParam, pValue, bArrowDown, bArrowUp, true);
+}
+
+void CKeyLabEsDawConnection::UpdateState ()
+{
+}
+
+void CKeyLabEsDawConnection::UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+}
+
+void CKeyLabEsDawConnection::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	//static const uint8_t pEncoder[] = {0x04, 0x01, 0x60};
+	//ArturiaShowNewCCValue (pKeyboard, pEncoder, ucCh, ucCC, ucValue);
+	switch (ucType)
+	{
+	case MIDI_DAW_CHANGE:
+		HandleMenuEvents (m_pUI, ucP1);
+		break;
+	}
+}
+
+CDAWController::CDAWController (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI)
+:	m_pSynthesizer (pSynthesizer),
+	m_pKeyboard (pKeyboard),
+	m_pConfig (pConfig),
+	m_pUI (pUI),
+	m_pDAWConnection (0)
+{
+}
+
+CDAWController::~CDAWController (void)
+{
+	delete m_pDAWConnection;
+}
+
+void CDAWController::OnConnect (void)
+{
+	static const uint8_t inquiry[] = {0xF0, 0x7E, 0x7F, 0x06, 0x01, 0xF7};
+
+	delete m_pDAWConnection;
+	m_pDAWConnection = 0;
+
+	m_pKeyboard->Send (inquiry, sizeof inquiry, 0);
+}
+
+void CDAWController::MIDISysexHandler (u8 *pPacket, unsigned nLength, unsigned nCable)
+{
+	static const uint8_t pMiniLab3[] =		{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x04, 0x04};
+	static const uint8_t pKeyLabEs_49[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x52};
+	static const uint8_t pKeyLabEs_61[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x54};
+	static const uint8_t pKeyLabEs_88[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x58};
+	static const uint8_t pKeyLab2_49[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x62};
+	static const uint8_t pKeyLab2_61[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x64};
+	static const uint8_t pKeyLab2_88[] = 	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x68};
+	static const uint8_t pKeyLabEs3_49[] =	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x72};
+	static const uint8_t pKeyLabEs3_61[] =	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x74};
+	static const uint8_t pKeyLabEs3_88[] =	{0xF0, 0x7E, 0x7F, 0x06, 0x02, 0x00, 0x20, 0x6B, 0x02, 0x00, 0x05, 0x78};
+
+	if (nLength > sizeof pMiniLab3 && memcmp (pPacket, pMiniLab3, sizeof pMiniLab3) == 0)
+	{
+		m_pDAWConnection = new CMiniLab3DawConnection (m_pSynthesizer, m_pKeyboard, m_pConfig, m_pUI);
+	}
+	else if (nLength > sizeof pKeyLabEs_49 && (
+		memcmp (pPacket, pKeyLabEs_49, sizeof pKeyLabEs_49) == 0 ||
+		memcmp (pPacket, pKeyLabEs_61, sizeof pKeyLabEs_61) == 0 ||
+		memcmp (pPacket, pKeyLabEs_88, sizeof pKeyLabEs_88) == 0))
+	{
+		m_pDAWConnection = new CKeyLabEsDawConnection (m_pSynthesizer, m_pKeyboard, m_pConfig, m_pUI);
+	}
+	else if (nLength > sizeof pKeyLab2_61 && (
+		memcmp (pPacket, pKeyLab2_49, sizeof pKeyLab2_49) == 0 ||
+		memcmp (pPacket, pKeyLab2_61, sizeof pKeyLab2_61) == 0 ||
+		memcmp (pPacket, pKeyLab2_88, sizeof pKeyLab2_88) == 0))
+	{
+		m_pDAWConnection = new CKeyLab2DawConnection (m_pSynthesizer, m_pKeyboard, m_pConfig, m_pUI);
+	}
+	else if (nLength > sizeof pKeyLabEs3_49 && (
+		memcmp (pPacket, pKeyLabEs3_49, sizeof pKeyLabEs3_49) == 0 ||
+		memcmp (pPacket, pKeyLabEs3_61, sizeof pKeyLabEs3_61) == 0 ||
+		memcmp (pPacket, pKeyLabEs3_88, sizeof pKeyLabEs3_88) == 0))
+	{
+		m_pDAWConnection = new CKeyLabEs3DawConnection (m_pSynthesizer, m_pKeyboard, m_pConfig, m_pUI);
+	}
+}
+
+void CDAWController::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+				bool bArrowDown, bool bArrowUp)
+{
+	if (m_pDAWConnection)
+		m_pDAWConnection->DisplayWrite (pMenu, pParam, pValue, bArrowDown, bArrowUp);
+}
+
+void CDAWController::UpdateState (void)
+{
+	if (m_pDAWConnection)
+		m_pDAWConnection->UpdateState ();
+}
+
+void CDAWController::UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+	if (m_pDAWConnection)
+		m_pDAWConnection->UpdateMenu (Type, ucPage, ucOP, ucTG);
+}
+
+void CDAWController::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	if (m_pDAWConnection)
+		m_pDAWConnection->MIDIListener (ucCable, ucChannel, ucType, ucP1, ucP2);
+}

--- a/src/dawcontroller.h
+++ b/src/dawcontroller.h
@@ -1,0 +1,54 @@
+// MiniDexed - Dexed FM synthesizer for bare metal Raspberry Pi
+// Copyright (C) 2024 The MiniDexed Team
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _dawcontroller_h
+#define _dawcontroller_h
+
+#include <circle/types.h>
+#include "uimenu.h"
+
+class CMIDIKeyboard;
+class CMiniDexed;
+class CDAWConnection;
+class CConfig;
+class CUserInterface;
+
+class CDAWController
+{
+public:
+	CDAWController (CMiniDexed *pSynthesizer, CMIDIKeyboard *pKeyboard, CConfig *pConfig, CUserInterface *pUI);
+	~CDAWController (void);
+
+	void OnConnect (void);
+	void MIDISysexHandler (u8 *pPacket, unsigned nLength, unsigned nCable);
+
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+			   bool bArrowDown, bool bArrowUp);
+	
+	void UpdateState (void);
+	void UpdateMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG);
+
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2);
+
+private:
+	CMiniDexed *m_pSynthesizer;
+	CMIDIKeyboard *m_pKeyboard;
+	CConfig *m_pConfig;
+	CUserInterface *m_pUI;
+	CDAWConnection *m_pDAWConnection;
+};
+
+#endif

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -374,6 +374,9 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 				if (m_pSynthesizer->SDFilterOut (nTG))
 					continue;
 
+				if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, nTG) == 0)
+					continue;
+
 				if (m_pSynthesizer->GetSysExEnable (nTG) && m_pSynthesizer->GetSysExChannel (nTG) == ucSysExChannel) {
 					LOGNOTE("MIDI-SYSEX: channel: %u, len: %u, TG: %u",ucSysExChannel,nLength,nTG);
 
@@ -492,6 +495,10 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			}
 		} else {
 			for (unsigned nTG = 0; nTG < m_pConfig->GetToneGenerators() && !bSystemCCHandled; nTG++) {
+
+				if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterEnabled, nTG) == 0)
+					continue;
+
 				if (   m_ChannelMap[nTG] == ucChannel
 				    || m_ChannelMap[nTG] == OmniMode) {
 					switch (ucType)

--- a/src/mididevice.cpp
+++ b/src/mididevice.cpp
@@ -22,6 +22,7 @@
 //
 
 #include <circle/logger.h>
+#include <circle/timer.h>
 #include "mididevice.h"
 #include "minidexed.h"
 #include "config.h"
@@ -57,7 +58,8 @@ CMIDIDevice::TDeviceMap CMIDIDevice::s_DeviceMap;
 CMIDIDevice::CMIDIDevice (CMiniDexed *pSynthesizer, CConfig *pConfig, CUserInterface *pUI)
 :	m_pSynthesizer (pSynthesizer),
 	m_pConfig (pConfig),
-	m_pUI (pUI)
+	m_pUI (pUI),
+	m_pRouteMap ()
 {
 	for (unsigned nTG = 0; nTG < CConfig::AllToneGenerators; nTG++)
 	{
@@ -237,14 +239,25 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 
 	m_MIDISpinLock.Acquire ();
 
+	u8 ucCable   = nCable;
 	u8 ucStatus  = pMessage[0];
 	u8 ucChannel = ucStatus & 0x0F;
 	u8 ucType    = ucStatus >> 4;
+	u8 ucP1      = pMessage[1];
+	u8 ucP2      = nLength >= 3 ? pMessage[2] : 0xFF;
+	bool bSkip    = false;
 
+	if (m_pRouteMap)
+		GetRoutedMIDI (m_pRouteMap, this, &ucCable, &ucChannel, &ucType, &ucP1, &ucP2, &bSkip);
+
+	if (bSkip)
+	{
+		// skip (and release mutex at the end)
+	}
 	// GLOBAL MIDI SYSEX
 
 	// Set MIDI Channel for TX816/TX216 SysEx
-	if (nLength == 7 &&
+	else if (nLength == 7 &&
 	    pMessage[0] == MIDI_SYSTEM_EXCLUSIVE_BEGIN &&
 	    pMessage[1] == 0x43 &&
 	    // pMessage[2] & 0x0F = SysEx channel
@@ -307,13 +320,13 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			{
 				if ((ucChannel == nPerfCh) || (nPerfCh == OmniMode))
 				{
-					if (pMessage[1] == MIDI_CC_BANK_SELECT_MSB)
+					if (ucP1 == MIDI_CC_BANK_SELECT_MSB)
 					{
-						m_pSynthesizer->BankSelectMSBPerformance (pMessage[2]);
+						m_pSynthesizer->BankSelectMSBPerformance (ucP2);
 					}
-					else if (pMessage[1] == MIDI_CC_BANK_SELECT_LSB)
+					else if (ucP1 == MIDI_CC_BANK_SELECT_LSB)
 					{
-						m_pSynthesizer->BankSelectLSBPerformance (pMessage[2]);
+						m_pSynthesizer->BankSelectLSBPerformance (ucP2);
 					}
 					else
 					{
@@ -335,7 +348,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			}
 			if (nLength == 3)
 			{
-				m_pUI->UIMIDICmdHandler (ucChannel, ucType, pMessage[1], pMessage[2]);
+				m_pUI->UIMIDICmdHandler (ucChannel, ucType, ucP1, ucP2);
 			}
 			break;
 
@@ -345,7 +358,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 			{
 				break;
 			}
-			m_pUI->UIMIDICmdHandler (ucChannel, ucType, pMessage[1], pMessage[2]);
+			m_pUI->UIMIDICmdHandler (ucChannel, ucType, ucP1, ucP2);
 			break;
 
 		case MIDI_PROGRAM_CHANGE:
@@ -357,7 +370,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 					if ((ucChannel == nPerfCh) || (nPerfCh == OmniMode))
 					{
 						//printf("Performance Select Channel %d\n", nPerfCh);
-						m_pSynthesizer->ProgramChangePerformance (pMessage[1]);
+						m_pSynthesizer->ProgramChangePerformance (ucP1);
 					}
 				}
 			}
@@ -509,17 +522,17 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 						}
 		
-						if (pMessage[2] > 0)
+						if (ucP2 > 0)
 						{
-							if (pMessage[2] <= 127)
+							if (ucP2 <= 127)
 							{
-								m_pSynthesizer->keydown (pMessage[1],
-											 pMessage[2], nTG);
+								m_pSynthesizer->keydown (ucP1,
+											 ucP2, nTG);
 							}
 						}
 						else
 						{
-							m_pSynthesizer->keyup (pMessage[1], nTG);
+							m_pSynthesizer->keyup (ucP1, nTG);
 						}
 						break;
 		
@@ -529,12 +542,12 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 						}
 		
-						m_pSynthesizer->keyup (pMessage[1], nTG);
+						m_pSynthesizer->keyup (ucP1, nTG);
 						break;
 		
 					case MIDI_CHANNEL_AFTERTOUCH:
 						
-						m_pSynthesizer->setAftertouch (pMessage[1], nTG);
+						m_pSynthesizer->setAftertouch (ucP1, nTG);
 						m_pSynthesizer->ControllersRefresh (nTG);
 						break;
 							
@@ -544,25 +557,25 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 						}
 		
-						switch (pMessage[1])
+						switch (ucP1)
 						{
 						case MIDI_CC_MODULATION:
-							m_pSynthesizer->setModWheel (pMessage[2], nTG);
+							m_pSynthesizer->setModWheel (ucP2, nTG);
 							m_pSynthesizer->ControllersRefresh (nTG);
 							break;
 								
 						case MIDI_CC_FOOT_PEDAL:
-							m_pSynthesizer->setFootController (pMessage[2], nTG);
+							m_pSynthesizer->setFootController (ucP2, nTG);
 							m_pSynthesizer->ControllersRefresh (nTG);
 							break;
 
 						case MIDI_CC_PORTAMENTO_TIME:
 							if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxPortamento, nTG))
-								m_pSynthesizer->setPortamentoTime (maplong (pMessage[2], 0, 127, 0, 99), nTG);
+								m_pSynthesizer->setPortamentoTime (maplong (ucP2, 0, 127, 0, 99), nTG);
 							break;
 
 						case MIDI_CC_BREATH_CONTROLLER:
-							m_pSynthesizer->setBreathController (pMessage[2], nTG);
+							m_pSynthesizer->setBreathController (ucP2, nTG);
 							m_pSynthesizer->ControllersRefresh (nTG);
 							break;
 								
@@ -570,14 +583,14 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							if (m_pSynthesizer->SDFilterOut (nTG))
 								break;
 
-							m_pSynthesizer->SetVolume (pMessage[2], nTG);
+							m_pSynthesizer->SetVolume (ucP2, nTG);
 							break;
 		
 						case MIDI_CC_PAN_POSITION:
 							if (m_pSynthesizer->GetTGParameter(CMiniDexed::TGParameterTGLink, nTG))
 								break;
 
-							m_pSynthesizer->SetPan (pMessage[2], nTG);
+							m_pSynthesizer->SetPan (ucP2, nTG);
 							break;
 		
 						case MIDI_CC_EXPRESSION:
@@ -588,60 +601,60 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 		
 						case MIDI_CC_BANK_SELECT_MSB:
-							m_pSynthesizer->BankSelectMSB (pMessage[2], nTG);
+							m_pSynthesizer->BankSelectMSB (ucP2, nTG);
 							break;
 		
 						case MIDI_CC_BANK_SELECT_LSB:
-							m_pSynthesizer->BankSelectLSB (pMessage[2], nTG);
+							m_pSynthesizer->BankSelectLSB (ucP2, nTG);
 							break;
 		
 						case MIDI_CC_SUSTAIN:
 							if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxSustain, nTG))
-								m_pSynthesizer->setSustain (pMessage[2] >= 64, nTG);
+								m_pSynthesizer->setSustain (ucP2 >= 64, nTG);
 							break;
 
 						case MIDI_CC_SOSTENUTO:
 							if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxSostenuto, nTG))
-								m_pSynthesizer->setSostenuto (pMessage[2] >= 64, nTG);
+								m_pSynthesizer->setSostenuto (ucP2 >= 64, nTG);
 							break;
 
 						case MIDI_CC_PORTAMENTO:
 							if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxPortamento, nTG))
-								m_pSynthesizer->setPortamentoMode (pMessage[2] >= 64, nTG);
+								m_pSynthesizer->setPortamentoMode (ucP2 >= 64, nTG);
 							break;
 
 						case MIDI_CC_HOLD2:
 							if (m_pSynthesizer->GetTGParameter (CMiniDexed::TGParameterMIDIRxHold2, nTG))
-								m_pSynthesizer->setHoldMode (pMessage[2] >= 64, nTG);
+								m_pSynthesizer->setHoldMode (ucP2 >= 64, nTG);
 							break;
 
 						case MIDI_CC_RESONANCE:
 							if (m_pSynthesizer->SDFilterOut (nTG))
 								break;
 
-							m_pSynthesizer->SetResonance (maplong (pMessage[2], 0, 127, 0, 99), nTG);
+							m_pSynthesizer->SetResonance (maplong (ucP2, 0, 127, 0, 99), nTG);
 							break;
 							
 						case MIDI_CC_FREQUENCY_CUTOFF:
 							if (m_pSynthesizer->SDFilterOut (nTG))
 								break;
 
-							m_pSynthesizer->SetCutoff (maplong (pMessage[2], 0, 127, 0, 99), nTG);
+							m_pSynthesizer->SetCutoff (maplong (ucP2, 0, 127, 0, 99), nTG);
 							break;
 
 						case MIDI_CC_EFFECT1_SEND:
-							m_pSynthesizer->SetFX1Send (maplong (pMessage[2], 0, 127, 0, 99), nTG);
+							m_pSynthesizer->SetFX1Send (maplong (ucP2, 0, 127, 0, 99), nTG);
 							break;
 
 						case MIDI_CC_EFFECT2_SEND:
-							m_pSynthesizer->SetFX2Send (maplong (pMessage[2], 0, 127, 0, 99), nTG);
+							m_pSynthesizer->SetFX2Send (maplong (ucP2, 0, 127, 0, 99), nTG);
 							break;
 
 						case MIDI_CC_DETUNE_LEVEL:
 							if (m_pSynthesizer->GetTGParameter(CMiniDexed::TGParameterTGLink, nTG))
 								break;
 
-							if (pMessage[2] == 0)
+							if (ucP2 == 0)
 							{
 								// 0 to 127, with 0 being no detune effect applied at all
 								m_pSynthesizer->SetMasterTune (0, nTG);
@@ -649,12 +662,12 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							else
 							{
 								// Scale to -99 to +99 cents
-								m_pSynthesizer->SetMasterTune (maplong (pMessage[2], 1, 127, -99, 99), nTG);
+								m_pSynthesizer->SetMasterTune (maplong (ucP2, 1, 127, -99, 99), nTG);
 							}
 							break;
 		
 						case MIDI_CC_ALL_SOUND_OFF:
-							m_pSynthesizer->panic (pMessage[2], nTG);
+							m_pSynthesizer->panic (ucP2, nTG);
 							break;
 		
 						case MIDI_CC_ALL_NOTES_OFF:
@@ -663,7 +676,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							// "Receivers should ignore an All Notes Off message while Omni is on (Modes 1 & 2)"
 							if (!m_pConfig->GetIgnoreAllNotesOff () && m_ChannelMap[nTG] != OmniMode)
 							{
-								m_pSynthesizer->notesOff (pMessage[2], nTG);
+								m_pSynthesizer->notesOff (ucP2, nTG);
 							}
 							break;
 
@@ -702,7 +715,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							// so it is possible to break out of the main TG loop too.
 							// Note: We handle this here so we get the TG MIDI channel checking.
 							if (!bSystemCCChecked) {
-								bSystemCCHandled = HandleMIDISystemCC(pMessage[1], pMessage[2]);
+								bSystemCCHandled = HandleMIDISystemCC(ucP1, ucP2);
 								bSystemCCChecked = true;
 							}
 							break;
@@ -713,7 +726,7 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 						// do program change only if enabled in config and not in "Performance Select Channel" mode
 						if( m_pConfig->GetMIDIRXProgramChange() && ( m_pSynthesizer->GetPerformanceSelectChannel() == Disabled) ) {
 							//printf("Program Change to %d (%d)\n", ucChannel, m_pSynthesizer->GetPerformanceSelectChannel());
-							m_pSynthesizer->ProgramChange (pMessage[1], nTG);
+							m_pSynthesizer->ProgramChange (ucP1, nTG);
 						}
 						break;
 		
@@ -723,8 +736,8 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 							break;
 						}
 		
-						s16 nValue = pMessage[1];
-						nValue |= (s16) pMessage[2] << 7;
+						s16 nValue = ucP1;
+						nValue |= (s16) ucP2 << 7;
 						nValue -= 0x2000;
 		
 						m_pSynthesizer->setPitchbend (nValue, nTG);
@@ -736,6 +749,9 @@ void CMIDIDevice::MIDIMessageHandler (const u8 *pMessage, size_t nLength, unsign
 				}
 			}
 		}
+
+		if (m_pRouteMap)
+			MIDIListener(ucCable, ucChannel, ucType, ucP1, ucP2);
 	}
 	m_MIDISpinLock.Release ();
 }
@@ -797,6 +813,11 @@ bool CMIDIDevice::HandleMIDISystemCC(const u8 ucCC, const u8 ucCCval)
 	}
 	
 	return false;
+}
+
+void CMIDIDevice::SetRouteMap (TMIDIRoute *pRouteMap)
+{
+	m_pRouteMap = pRouteMap;
 }
 
 void CMIDIDevice::HandleSystemExclusive(const uint8_t* pMessage, const size_t nLength, const unsigned nCable, const uint8_t nTG)
@@ -907,4 +928,103 @@ void CMIDIDevice::SendSystemExclusiveVoice(uint8_t nVoice, const std::string& de
     } else {
         LOGWARN("No device found in s_DeviceMap for name: %s", deviceName.c_str());
     }
+}
+
+void CMIDIDevice::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+}
+
+void CMIDIDevice::s_HandleTimerTimeout(TKernelTimerHandle hTimer, void *pParam, void *pContext)
+{
+	CMIDIDevice *pDevice = static_cast<CMIDIDevice*>(pParam);
+	TMIDIRoute *pRoute = static_cast<TMIDIRoute*>(pContext);
+	TMIDIRoute *pTarget = pRoute + pRoute->ucTimerTarget;
+
+	pRoute->hTimer = 0;
+	pRoute->bGroupActive = false;
+	pRoute->bGroupHold = false;
+	if (!pTarget->bSkip)
+		pDevice->MIDIListener (pTarget->ucSCable, pTarget->ucDCh, pTarget->ucDType, pTarget->ucDP1, pTarget->ucDP2);
+}
+
+static bool RouteMatch (u8 ucSP, u8 ucP)
+{
+	return ucSP == ucP ||
+		ucSP == 0xFF ||
+		ucSP == TMIDIRoute::LtCenter && ucP < 64 ||
+		ucSP == TMIDIRoute::GtCenter && ucP > 64 ||
+		ucSP == TMIDIRoute::Betw00n07 && ucP >= 0 && ucP <= 7 ||
+		ucSP == TMIDIRoute::Betw08n15 && ucP >= 8 && ucP <= 15 ||
+		ucSP == TMIDIRoute::Betw16n23 && ucP >= 16 && ucP <= 23;
+}
+
+void GetRoutedMIDI (TMIDIRoute *pRouteMap, CMIDIDevice *pDevice, u8 *pCable, u8 *pCh, u8 *pType, u8 *pP1, u8 *pP2, bool *bSkip)
+{
+	assert (pRouteMap);
+	for (TMIDIRoute *r = pRouteMap; r->ucSCable != 0xFF ; r++)
+	{
+		if (r->ucSCable == *pCable &&
+			(r->ucSCh == *pCh || r->ucSCh >= 16) &&
+			(r->ucSType == *pType || r->ucSType >= 16) &&
+			RouteMatch (r->ucSP1, *pP1) &&
+			RouteMatch (r->ucSP2, *pP2)
+			)
+		{
+			if (r->usTimerExpire)
+				r->hTimer = CTimer::Get ()->StartKernelTimer (MSEC2HZ(r->usTimerExpire), CMIDIDevice::s_HandleTimerTimeout, pDevice, r);
+				
+			if (r->usTimerExpire || r->bGroupHead)
+				r->bGroupActive = true;
+
+			if (r->bSkip) {
+				*bSkip = true;
+				return;
+			}
+
+			if (r->bGroup) {
+				TMIDIRoute *parent = r - 1;
+				for (; parent > pRouteMap && parent->bGroup; parent--);
+
+				if (parent->hTimer) {
+					CTimer::Get ()->CancelKernelTimer (parent->hTimer);
+					parent->hTimer = 0;
+				}
+				
+				if (!r->bGroupHold)
+					parent->bGroupHold = false;
+
+				if (!parent->bGroupActive && !parent->bGroupHold) {
+					// skip at the end if not captured by other routes
+					*bSkip = true;
+					continue;
+				}	
+
+				// hold the group for bGroupHold routes
+				if (r->bGroupHold)
+					parent->bGroupHold = true;
+
+				parent->bGroupActive = false;
+			}
+
+			*pCh = r->ucDCh;
+			*pType = r->ucDType;
+			if (r->ucDP1 <= 127)
+				*pP1 = r->ucDP1;
+			if (r->ucDP1 == TMIDIRoute::P2)
+				*pP1 = *pP2;
+			if (r->ucDP2 <= 127)
+				*pP2 = r->ucDP2;
+			if (r->bToggle)
+				r->ucDP2 = r->ucDP2 ? 0x0 : 0x7F;
+			*bSkip = false;
+			return;
+		}
+	}
+}
+
+TMIDIRoute::~TMIDIRoute ()
+{
+	if (hTimer)
+		CTimer::Get ()->CancelKernelTimer (hTimer);
+	hTimer = 0;
 }

--- a/src/midikeyboard.cpp
+++ b/src/midikeyboard.cpp
@@ -25,19 +25,26 @@
 #include <cstring>
 #include <assert.h>
 
+#define DISPLAY_REFRESH_RATE_US 25000
+
 CMIDIKeyboard::CMIDIKeyboard (CMiniDexed *pSynthesizer, CConfig *pConfig, CUserInterface *pUI, unsigned nInstance)
 :	CMIDIDevice (pSynthesizer, pConfig, pUI),
 	m_nSysExIdx (0),
 	m_nInstance (nInstance),
-	m_pMIDIDevice (0)
+	m_pMIDIDevice (0),
+	m_pDAWController (0)
 {
 	m_DeviceName.Format ("umidi%u", nInstance+1);
 
 	AddDevice (m_DeviceName);
+
+	if (pConfig->GetDAWControllerEnabled ())
+		m_pDAWController = new CDAWController (pSynthesizer, this, pConfig, pUI);
 }
 
 CMIDIKeyboard::~CMIDIKeyboard (void)
 {
+	delete m_pDAWController;
 }
 
 void CMIDIKeyboard::Process (boolean bPlugAndPlayUpdated)
@@ -55,6 +62,15 @@ void CMIDIKeyboard::Process (boolean bPlugAndPlayUpdated)
 		delete [] Entry.pMessage;
 	}
 
+	unsigned time = CTimer::GetClockTicks ();
+	unsigned diff = time - m_LastDisplayRefreshTime;
+	if (m_LastDisplayEntry.nLength && diff > DISPLAY_REFRESH_RATE_US)
+	{
+		m_pMIDIDevice->SendPlainMIDI (m_LastDisplayEntry.nCable, m_LastDisplayEntry.pMessage, m_LastDisplayEntry.nLength);
+		m_LastDisplayEntry.nLength = 0;
+		m_LastDisplayRefreshTime = time;
+	}
+
 	if (!bPlugAndPlayUpdated)
 	{
 		return;
@@ -69,6 +85,9 @@ void CMIDIKeyboard::Process (boolean bPlugAndPlayUpdated)
 			m_pMIDIDevice->RegisterPacketHandler (MIDIPacketHandler, this);
 
 			m_pMIDIDevice->RegisterRemovedHandler (DeviceRemovedHandler, this);
+
+			if (m_pDAWController)
+				m_pDAWController->OnConnect();
 		}
 	}
 }
@@ -83,6 +102,15 @@ void CMIDIKeyboard::Send (const u8 *pMessage, size_t nLength, unsigned nCable)
 	memcpy (Entry.pMessage, pMessage, nLength);
 
 	m_SendQueue.push (Entry);
+}
+
+void CMIDIKeyboard::SendDisplay (const u8 *pMessage, size_t nLength, unsigned nCable)
+{
+	assert (nLength <= sizeof m_LastMessage);
+
+	m_LastDisplayEntry.nLength = nLength;
+	m_LastDisplayEntry.nCable = nCable;
+	memcpy (m_LastMessage, pMessage, nLength);
 }
 
 // Most packets will be passed straight onto the main MIDI message handler
@@ -122,6 +150,10 @@ void CMIDIKeyboard::USBMIDIMessageHandler (u8 *pPacket, unsigned nLength, unsign
 				m_SysEx[m_nSysExIdx++] = pPacket[i];
 				//printf ("SysEx End    Idx=%d\n", m_nSysExIdx);
 				MIDIMessageHandler (m_SysEx, m_nSysExIdx, nCable);
+
+				if (m_pDAWController)
+					m_pDAWController->MIDISysexHandler (m_SysEx, m_nSysExIdx, nCable);
+
 				// Reset ready for next time
 				m_nSysExIdx = 0;
 			}
@@ -159,4 +191,29 @@ void CMIDIKeyboard::DeviceRemovedHandler (CDevice *pDevice, void *pContext)
 	assert (pThis != 0);
 
 	pThis->m_pMIDIDevice = 0;
+}
+
+void CMIDIKeyboard::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+			   bool bArrowDown, bool bArrowUp)
+{
+	if (m_pMIDIDevice && m_pDAWController)
+		m_pDAWController->DisplayWrite (pMenu, pParam, pValue, bArrowDown, bArrowUp);
+}
+
+void CMIDIKeyboard::UpdateDAWState (void)
+{
+	if (m_pMIDIDevice && m_pDAWController)
+		m_pDAWController->UpdateState ();
+}
+
+void CMIDIKeyboard::UpdateDAWMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+	if (m_pMIDIDevice && m_pDAWController)
+		m_pDAWController->UpdateMenu (Type, ucPage, ucOP, ucTG);
+}
+
+void CMIDIKeyboard::MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2)
+{
+	if (m_pDAWController)
+		m_pDAWController->MIDIListener (ucCable, ucChannel, ucType, ucP1, ucP2);
 }

--- a/src/midikeyboard.h
+++ b/src/midikeyboard.h
@@ -25,6 +25,7 @@
 
 #include "mididevice.h"
 #include "config.h"
+#include "dawcontroller.h"
 #include <circle/usb/usbmidi.h>
 #include <circle/device.h>
 #include <circle/string.h>
@@ -44,12 +45,21 @@ public:
 	void Process (boolean bPlugAndPlayUpdated);
 
 	void Send (const u8 *pMessage, size_t nLength, unsigned nCable = 0) override;
+	void SendDisplay (const u8 *pMessage, size_t nLength, unsigned nCable = 0);
+
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+			   bool bArrowDown, bool bArrowUp);
+	
+	void UpdateDAWState (void);
+	void UpdateDAWMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG);
 
 private:
 	static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength, unsigned nDevice, void *pParam);
 	static void DeviceRemovedHandler (CDevice *pDevice, void *pContext);
 	
 	void USBMIDIMessageHandler (u8 *pPacket, unsigned nLength, unsigned nCable, unsigned nDevice);
+
+	void MIDIListener (u8 ucCable, u8 ucChannel, u8 ucType, u8 ucP1, u8 ucP2) override;
 
 private:
 	struct TSendQueueEntry
@@ -68,6 +78,11 @@ private:
 	CUSBMIDIDevice * volatile m_pMIDIDevice;
 
 	std::queue<TSendQueueEntry> m_SendQueue;
+	u8 m_LastMessage[256];
+	TSendQueueEntry m_LastDisplayEntry = {m_LastMessage, 0, 0};
+	unsigned m_LastDisplayRefreshTime = 0;
+
+	CDAWController *m_pDAWController;
 };
 
 #endif

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -552,6 +552,7 @@ void CMiniDexed::Run (unsigned nCore)
 		while (m_CoreStatus[nCore] != CoreStatusExit)
 		{
 			ProcessSound ();
+			WaitForEvent ();
 		}
 	}
 	else								// core 2 and 3

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -155,6 +155,8 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 		m_nEQPreLowcut[i] = 0;
 		m_nEQPreHighcut[i] = 60;
 
+		m_bEnabled[i] = 1;
+
 		// Active the required number of active TGs
 		if (i<m_nToneGenerators)
 		{
@@ -1767,6 +1769,8 @@ void CMiniDexed::SetTGParameter (TTGParameter Parameter, int nValue, unsigned nT
 		case TGParameterMonoMode:		setMonoMode (nValue , i);	break; 
 		case TGParameterTGLink:			setTGLink(nValue, i);		break;
 
+		case TGParameterEnabled:		setEnabled (nValue, i);		break;
+
 		case TGParameterMWRange:					setModController(0, 0, nValue, i); break;
 		case TGParameterMWPitch:					setModController(0, 1, nValue, i); break;
 		case TGParameterMWAmplitude:				setModController(0, 2, nValue, i); break;
@@ -1861,8 +1865,8 @@ int CMiniDexed::GetTGParameter (TTGParameter Parameter, unsigned nTG)
 	case TGParameterNoteLimitHigh:		return m_nNoteLimitHigh[nTG];
 	case TGParameterNoteShift:		return m_nNoteShift[nTG];
 	case TGParameterMonoMode:		return m_bMonoMode[nTG] ? 1 : 0; 
-
 	case TGParameterTGLink:			return m_nTGLink[nTG];
+	case TGParameterEnabled:		return m_bEnabled[nTG] ? 1 : 0; 
 	
 	case TGParameterMWRange:					return getModController(0, 0, nTG);
 	case TGParameterMWPitch:					return getModController(0, 1, nTG);
@@ -2539,6 +2543,17 @@ void CMiniDexed::setTGLink(uint8_t nTGLink, uint8_t nTG)
 	m_UI.ParameterChanged ();
 }
 
+void CMiniDexed::setEnabled (uint8_t enabled, uint8_t nTG)
+{
+	assert (nTG < CConfig::AllToneGenerators);
+	if (nTG >= m_nToneGenerators) return;  // Not an active TG
+	assert (m_pTG[nTG]);
+
+	m_bEnabled[nTG] = enabled != 0;
+	
+	m_UI.ParameterChanged ();
+}
+
 void CMiniDexed::setPitchbendRange(uint8_t range, uint8_t nTG)
 {
 	range = constrain (range, 0, 12);
@@ -3053,6 +3068,7 @@ void CMiniDexed::LoadPerformanceParameters(void)
 
 		setMonoMode(m_PerformanceConfig.GetMonoMode(nTG) ? 1 : 0, nTG); 
 		setTGLink(m_PerformanceConfig.GetTGLink(nTG), nTG);
+		setEnabled(1, nTG);
 
 		SetFX1Send (m_PerformanceConfig.GetFX1Send (nTG), nTG);
 		SetFX2Send (m_PerformanceConfig.GetFX2Send (nTG), nTG);

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -1954,6 +1954,7 @@ void CMiniDexed::SetVoiceParameter (uint8_t uchOffset, uint8_t uchValue, unsigne
 
 		m_pTG[i]->setVoiceDataElement (offset, uchValue);
 	}
+	m_UI.ParameterChanged ();
 }
 
 uint8_t CMiniDexed::GetVoiceParameter (uint8_t uchOffset, unsigned nOP, unsigned nTG)
@@ -2892,6 +2893,33 @@ bool CMiniDexed::SDFilterOut (uint8_t nTG)
 	case SDFilter::Type::TG: return nTG != m_SDFilter.param;
 	case SDFilter::Type::MIDIChannel: return m_nMIDIChannel[nTG] != m_SDFilter.param;
 	default: return false;
+	}
+}
+
+void CMiniDexed::DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+			       bool bArrowDown, bool bArrowUp)
+{
+	m_UI.DisplayWrite (pMenu, pParam, pValue, bArrowDown, bArrowUp);
+
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		m_pMIDIKeyboard[i]->DisplayWrite (pMenu, pParam, pValue, bArrowDown, bArrowUp);
+	}
+}
+
+void CMiniDexed::UpdateDAWState ()
+{
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		m_pMIDIKeyboard[i]->UpdateDAWState ();
+	}
+}
+
+void CMiniDexed::UpdateDAWMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG)
+{
+	for (unsigned i = 0; i < CConfig::MaxUSBMIDIDevices; i++)
+	{
+		m_pMIDIKeyboard[i]->UpdateDAWMenu (Type, ucPage, ucOP, ucTG);
 	}
 }
 

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -137,8 +137,8 @@ public:
 	void SetEQPreHighcut (unsigned nValue, unsigned nTG);
 
 	void setMonoMode(uint8_t mono, uint8_t nTG);
-
 	void setTGLink(uint8_t nTGLink, uint8_t nTG);
+	void setEnabled(uint8_t enabled, uint8_t nTG);
 
 	void setPitchbendRange(uint8_t range, uint8_t nTG);
 	void setPitchbendStep(uint8_t step, uint8_t nTG);
@@ -250,7 +250,8 @@ public:
 		TGParameterNoteShift,
 		TGParameterMonoMode,  
 		TGParameterTGLink,
-				
+		TGParameterEnabled,
+		
 		TGParameterMWRange,
 		TGParameterMWPitch,
 		TGParameterMWAmplitude,
@@ -365,9 +366,9 @@ private:
 	unsigned m_nPortamentoGlissando[CConfig::AllToneGenerators];	
 	unsigned m_nPortamentoTime[CConfig::AllToneGenerators];	
 	bool m_bMonoMode[CConfig::AllToneGenerators]; 
-
 	unsigned m_nTGLink[CConfig::AllToneGenerators];
-				
+	bool m_bEnabled[CConfig::AllToneGenerators];
+
 	unsigned m_nModulationWheelRange[CConfig::AllToneGenerators];
 	unsigned m_nModulationWheelTarget[CConfig::AllToneGenerators];
 	unsigned m_nFootControlRange[CConfig::AllToneGenerators];

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -313,6 +313,12 @@ public:
 	void UpdateNetwork();
 	const CIPAddress& GetNetworkIPAddress();
 
+	void DisplayWrite (const char *pMenu, const char *pParam, const char *pValue,
+			   bool bArrowDown, bool bArrowUp);
+
+	void UpdateDAWState ();
+	void UpdateDAWMenu (CUIMenu::TCPageType Type, s8 ucPage, u8 ucOP, u8 ucTG);
+
 private:
 	int16_t ApplyNoteLimits (int16_t pitch, unsigned nTG);	// returns < 0 to ignore note
 	uint8_t m_uchOPMask[CConfig::AllToneGenerators];

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -166,6 +166,9 @@ MIDIButtonActionTGDown=click
 # Can be adjusted if the controller sends dec / inc messages too quickly.
 MIDIRelativeDebounceTime=0
 
+# DAW Controller (Arturia MiniLab 3, KeyLab Essential, KeyLab Essential 3, Keylab mkII)
+DAWControllerEnabled=0
+
 # KY-040 Rotary Encoder
 EncoderEnabled=1
 EncoderPinClock=10

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -91,6 +91,7 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 	{"Note Limit",		MenuHandler,	s_EditNoteLimitMenu},
 	{"Poly/Mono",		EditTGParameter,	0,	CMiniDexed::TGParameterMonoMode}, 
 	{"TG-Link",		EditTGParameter,	0,	CMiniDexed::TGParameterTGLink},
+	{"Enabled",			EditTGParameter,	0,	CMiniDexed::TGParameterEnabled},
 	{"Modulation",		MenuHandler,		s_ModulationMenu},
 	{"MIDI",		MenuHandler,		s_MIDIMenu},
 	{"EQ",		MenuHandler,		s_EQMenu},
@@ -612,6 +613,7 @@ CUIMenu::TParameter CUIMenu::s_TGParameter[CMiniDexed::TGParameterUnknown] =
 	{-24,	24,					1, ToMIDINoteShift},	// TGParameterNoteShift
 	{0,	1,					1, ToPolyMono}, 		// TGParameterMonoMode 
 	{0,	4,					1, ToTGLinkName}, 		// TGParameterTGLink
+	{0, 1, 1, ToOnOff}, // TGParameterEnabled
 	{0, 99, 1}, //MW Range
 	{0, 1, 1, ToOnOff}, //MW Pitch
 	{0, 1, 1, ToOnOff}, //MW Amp

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -75,21 +75,21 @@ const CUIMenu::TMenuItem CUIMenu::s_MainMenu[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 {
-	{"Voice",	EditProgramNumber},
+	{"Voice",	EditProgramNumber,	0,	CMiniDexed::TGParameterProgram,	"Voice"},
 	{"Bank",	EditVoiceBankNumber},
-	{"Volume",	EditTGParameter,	0,	CMiniDexed::TGParameterVolume},
+	{"Volume",	EditTGParameter,	0,	CMiniDexed::TGParameterVolume,	"Vol"},
 #ifdef ARM_ALLOW_MULTI_CORE
-	{"Pan",		EditTGParameter,	0,	CMiniDexed::TGParameterPan},
-	{"FX1-Send",	EditTGParameter,	0,	CMiniDexed::TGParameterFX1Send},
-	{"FX2-Send",	EditTGParameter,	0,	CMiniDexed::TGParameterFX2Send},
+	{"Pan",		EditTGParameter,	0,	CMiniDexed::TGParameterPan,	"Pan"},
+	{"FX1-Send",	EditTGParameter,	0,	CMiniDexed::TGParameterFX1Send,	"FX1"},
+	{"FX2-Send",	EditTGParameter,	0,	CMiniDexed::TGParameterFX2Send,	"FX2"},
 #endif
-	{"Detune",	EditTGParameter,	0,	CMiniDexed::TGParameterMasterTune},
-	{"Cutoff",	EditTGParameter,	0,	CMiniDexed::TGParameterCutoff},
-	{"Resonance",	EditTGParameter,	0,	CMiniDexed::TGParameterResonance},
+	{"Detune",	EditTGParameter,	0,	CMiniDexed::TGParameterMasterTune,	"DeT"},
+	{"Cutoff",	EditTGParameter,	0,	CMiniDexed::TGParameterCutoff,	"Cut"},
+	{"Resonance",	EditTGParameter,	0,	CMiniDexed::TGParameterResonance,	"Res"},
 	{"Pitch Bend",	MenuHandler,		s_EditPitchBendMenu},
 	{"Portamento",		MenuHandler,		s_EditPortamentoMenu},
 	{"Note Limit",		MenuHandler,	s_EditNoteLimitMenu},
-	{"Poly/Mono",		EditTGParameter,	0,	CMiniDexed::TGParameterMonoMode}, 
+	{"Poly/Mono",		EditTGParameter,	0,	CMiniDexed::TGParameterMonoMode,	"P/M"}, 
 	{"TG-Link",		EditTGParameter,	0,	CMiniDexed::TGParameterTGLink},
 	{"Enabled",			EditTGParameter,	0,	CMiniDexed::TGParameterEnabled},
 	{"Modulation",		MenuHandler,		s_ModulationMenu},
@@ -102,28 +102,28 @@ const CUIMenu::TMenuItem CUIMenu::s_TGMenu[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_EditCompressorMenu[] =
 {
-	{"Enable",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorEnable},
-	{"Pre Gain",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorPreGain},
-	{"Threshold",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorThresh},
-	{"Ratio",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRatio},
-	{"Attack",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorAttack},
-	{"Release",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRelease},
-	{"Makeup Gain",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorMakeupGain},
+	{"Enable",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorEnable,	"CEn"},
+	{"Pre Gain",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorPreGain,	"CPg"},
+	{"Threshold",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorThresh,	"CTh"},
+	{"Ratio",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRatio,		"CRa"},
+	{"Attack",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorAttack,	"CAt"},
+	{"Release",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorRelease,	"CRe"},
+	{"Makeup Gain",	EditTGParameter2,	0,	CMiniDexed::TGParameterCompressorMakeupGain,	"CPm"},
 	{0}
 };
 
 const CUIMenu::TMenuItem CUIMenu::s_EditPitchBendMenu[] =
 {
-	{"Bend Range",	EditTGParameter2,	0,	CMiniDexed::TGParameterPitchBendRange},
-	{"Bend Step",		EditTGParameter2,	0,	CMiniDexed::TGParameterPitchBendStep},
+	{"Bend Range",	EditTGParameter2,	0,	CMiniDexed::TGParameterPitchBendRange,	"PiBR"},
+	{"Bend Step",		EditTGParameter2,	0,	CMiniDexed::TGParameterPitchBendStep,	"PiBS"},
 	{0}
 };
 
 const CUIMenu::TMenuItem CUIMenu::s_EditPortamentoMenu[] =
 {
-	{"Mode",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoMode},
-	{"Glissando",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoGlissando},
-	{"Time",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoTime},
+	{"Mode",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoMode,	"PorM"},
+	{"Glissando",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoGlissando,	"PorG"},
+	{"Time",		EditTGParameter2,	0,	CMiniDexed::TGParameterPortamentoTime,	"PorT"},
 	{0}
 };
 
@@ -137,10 +137,10 @@ const CUIMenu::TMenuItem CUIMenu::s_EditNoteLimitMenu[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_ModulationMenu[] =
 {
-	{"Mod. Wheel",		MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterMWRange},
-	{"Foot Control",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterFCRange},
-	{"Breath Control",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterBCRange},
-	{"Aftertouch",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterATRange},
+	{"Mod. Wheel",		MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterMWRange,	"MWR"},
+	{"Foot Control",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterFCRange,	"FCR"},
+	{"Breath Control",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterBCRange,	"BCR"},
+	{"Aftertouch",	MenuHandler,	s_ModulationMenuParameters,	CMiniDexed::TGParameterATRange,	"ATR"},
 	{0}
 };
 
@@ -155,7 +155,7 @@ const CUIMenu::TMenuItem CUIMenu::s_ModulationMenuParameters[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_MIDIMenu[] =
 {
-	{"Channel",		EditTGParameter2,	0,	CMiniDexed::TGParameterMIDIChannel},
+	{"Channel",		EditTGParameter2,	0,	CMiniDexed::TGParameterMIDIChannel,	"Chan"},
 	{"SysEx Channel",	EditTGParameter2,	0,	CMiniDexed::TGParameterSysExChannel},
 	{"SysEx Enable",	EditTGParameter2,	0,	CMiniDexed::TGParameterSysExEnable},
 	{"Sustain Rx",		EditTGParameter2,	0,	CMiniDexed::TGParameterMIDIRxSustain},
@@ -167,14 +167,14 @@ const CUIMenu::TMenuItem CUIMenu::s_MIDIMenu[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_EQMenu[] =
 {
-	{"Low Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQLow},
-	{"Mid Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQMid},
-	{"High Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQHigh},
-	{"Gain",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQGain},
-	{"Low-Mid Freq",	EditTGParameter2,	0,	CMiniDexed::TGParameterEQLowMidFreq},
-	{"Mid-High Freq",	EditTGParameter2,	0,	CMiniDexed::TGParameterEQMidHighFreq},
-	{"Pre Lowcut",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQPreLowcut},
-	{"Pre Highcut",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQPreHighcut},
+	{"Low Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQLow,		"TQL"},
+	{"Mid Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQMid,		"TQM"},
+	{"High Level",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQHigh,		"TQH"},
+	{"Gain",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQGain,		"TQG"},
+	{"Low-Mid Freq",	EditTGParameter2,	0,	CMiniDexed::TGParameterEQLowMidFreq,	"TQLM"},
+	{"Mid-High Freq",	EditTGParameter2,	0,	CMiniDexed::TGParameterEQMidHighFreq,	"TQMH"},
+	{"Pre Lowcut",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQPreLowcut,	"TQLC"},
+	{"Pre Highcut",		EditTGParameter2,	0,	CMiniDexed::TGParameterEQPreHighcut,	"TQHC"},
 	{0}
 };
 
@@ -365,13 +365,13 @@ const CUIMenu::TMenuItem CUIMenu::s_DreamDelayMenu[] =
 
 const CUIMenu::TMenuItem CUIMenu::s_PlateReverbMenu[] =
 {
-	{"Mix Dry:Wet",	EditFXParameter2,	0,	FX::FXParameterPlateReverbMix},
-	{"Size",	EditFXParameter2,	0,	FX::FXParameterPlateReverbSize},
-	{"High damp",	EditFXParameter2,	0,	FX::FXParameterPlateReverbHighDamp},
-	{"Low damp",	EditFXParameter2,	0,	FX::FXParameterPlateReverbLowDamp},
-	{"Low pass",	EditFXParameter2,	0,	FX::FXParameterPlateReverbLowPass},
-	{"Diffusion",	EditFXParameter2,	0,	FX::FXParameterPlateReverbDiffusion},
-	{"Bypass",	EditFXParameter2,	0,	FX::FXParameterPlateReverbBypass},
+	{"Mix Dry:Wet",	EditFXParameter2,	0,	FX::FXParameterPlateReverbMix,	"RvMx"},
+	{"Size",	EditFXParameter2,	0,	FX::FXParameterPlateReverbSize,	"RvS"},
+	{"High damp",	EditFXParameter2,	0,	FX::FXParameterPlateReverbHighDamp,	"RvHD"},
+	{"Low damp",	EditFXParameter2,	0,	FX::FXParameterPlateReverbLowDamp,	"RvLD"},
+	{"Low pass",	EditFXParameter2,	0,	FX::FXParameterPlateReverbLowPass,	"RvLP"},
+	{"Diffusion",	EditFXParameter2,	0,	FX::FXParameterPlateReverbDiffusion,	"RvDi"},
+	{"Bypass",	EditFXParameter2,	0,	FX::FXParameterPlateReverbBypass,	"RvBP"},
 	{0}
 };
 
@@ -513,53 +513,53 @@ const CUIMenu::TMenuItem CUIMenu::s_EditVoiceMenu[] =
 	{"OP4",		MenuHandler,		s_OperatorMenu, 3},
 	{"OP5",		MenuHandler,		s_OperatorMenu, 4},
 	{"OP6",		MenuHandler,		s_OperatorMenu, 5},
-	{"Algorithm",	EditVoiceParameter,	0,		DEXED_ALGORITHM},
-	{"Feedback",	EditVoiceParameter,	0,		DEXED_FEEDBACK},
-	{"P EG Rate 1",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R1},
-	{"P EG Rate 2",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R2},
-	{"P EG Rate 3",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R3},
-	{"P EG Rate 4",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R4},
-	{"P EG Level 1",EditVoiceParameter,	0,		DEXED_PITCH_EG_L1},
-	{"P EG Level 2",EditVoiceParameter,	0,		DEXED_PITCH_EG_L2},
-	{"P EG Level 3",EditVoiceParameter,	0,		DEXED_PITCH_EG_L3},
-	{"P EG Level 4",EditVoiceParameter,	0,		DEXED_PITCH_EG_L4},
-	{"Osc Key Sync",EditVoiceParameter,	0,		DEXED_OSC_KEY_SYNC},
-	{"LFO Speed",	EditVoiceParameter,	0,		DEXED_LFO_SPEED},
-	{"LFO Delay",	EditVoiceParameter,	0,		DEXED_LFO_DELAY},
-	{"LFO PMD",	EditVoiceParameter,	0,		DEXED_LFO_PITCH_MOD_DEP},
-	{"LFO AMD",	EditVoiceParameter,	0,		DEXED_LFO_AMP_MOD_DEP},
-	{"LFO Sync",	EditVoiceParameter,	0,		DEXED_LFO_SYNC},
-	{"LFO Wave",	EditVoiceParameter,	0,		DEXED_LFO_WAVE},
-	{"P Mod Sens.",	EditVoiceParameter,	0,		DEXED_LFO_PITCH_MOD_SENS},
-	{"Transpose",	EditVoiceParameter,	0,		DEXED_TRANSPOSE},
+	{"Algorithm",	EditVoiceParameter,	0,		DEXED_ALGORITHM,	"Alg"},
+	{"Feedback",	EditVoiceParameter,	0,		DEXED_FEEDBACK,	"FB"},
+	{"P EG Rate 1",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R1,	"PR1"},
+	{"P EG Rate 2",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R2,	"PR2"},
+	{"P EG Rate 3",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R3,	"PR3"},
+	{"P EG Rate 4",	EditVoiceParameter,	0,		DEXED_PITCH_EG_R4,	"PR4"},
+	{"P EG Level 1",EditVoiceParameter,	0,		DEXED_PITCH_EG_L1,	"PL1"},
+	{"P EG Level 2",EditVoiceParameter,	0,		DEXED_PITCH_EG_L2,	"PL2"},
+	{"P EG Level 3",EditVoiceParameter,	0,		DEXED_PITCH_EG_L3,	"PL3"},
+	{"P EG Level 4",EditVoiceParameter,	0,		DEXED_PITCH_EG_L4,	"PL4"},
+	{"Osc Key Sync",EditVoiceParameter,	0,		DEXED_OSC_KEY_SYNC,	"OKS"},
+	{"LFO Speed",	EditVoiceParameter,	0,		DEXED_LFO_SPEED,	"LSP"},
+	{"LFO Delay",	EditVoiceParameter,	0,		DEXED_LFO_DELAY,	"LDE"},
+	{"LFO PMD",	EditVoiceParameter,	0,		DEXED_LFO_PITCH_MOD_DEP,	"LPMD"},
+	{"LFO AMD",	EditVoiceParameter,	0,		DEXED_LFO_AMP_MOD_DEP,	"LAMD"},
+	{"LFO Sync",	EditVoiceParameter,	0,		DEXED_LFO_SYNC,	"LSYN"},
+	{"LFO Wave",	EditVoiceParameter,	0,		DEXED_LFO_WAVE,	"LWAV"},
+	{"P Mod Sens.",	EditVoiceParameter,	0,		DEXED_LFO_PITCH_MOD_SENS,	"LPMS"},
+	{"Transpose",	EditVoiceParameter,	0,		DEXED_TRANSPOSE,	"TRP"},
 	{"Name",	InputTxt,0 , 3}, 
 	{0}
 };
 
 const CUIMenu::TMenuItem CUIMenu::s_OperatorMenu[] =
 {
-	{"Output Level",EditOPParameter,	0,	DEXED_OP_OUTPUT_LEV},
-	{"Freq Coarse",	EditOPParameter,	0,	DEXED_OP_FREQ_COARSE},
-	{"Freq Fine",	EditOPParameter,	0,	DEXED_OP_FREQ_FINE},
-	{"Osc Detune",	EditOPParameter,	0,	DEXED_OP_OSC_DETUNE},
-	{"Osc Mode",	EditOPParameter,	0,	DEXED_OP_OSC_MODE},
-	{"EG Rate 1",	EditOPParameter,	0,	DEXED_OP_EG_R1},
-	{"EG Rate 2",	EditOPParameter,	0,	DEXED_OP_EG_R2},
-	{"EG Rate 3",	EditOPParameter,	0,	DEXED_OP_EG_R3},
-	{"EG Rate 4",	EditOPParameter,	0,	DEXED_OP_EG_R4},
-	{"EG Level 1",	EditOPParameter,	0,	DEXED_OP_EG_L1},
-	{"EG Level 2",	EditOPParameter,	0,	DEXED_OP_EG_L2},
-	{"EG Level 3",	EditOPParameter,	0,	DEXED_OP_EG_L3},
-	{"EG Level 4",	EditOPParameter,	0,	DEXED_OP_EG_L4},
-	{"Break Point",	EditOPParameter,	0,	DEXED_OP_LEV_SCL_BRK_PT},
-	{"L Key Depth",	EditOPParameter,	0,	DEXED_OP_SCL_LEFT_DEPTH},
-	{"R Key Depth",	EditOPParameter,	0,	DEXED_OP_SCL_RGHT_DEPTH},
-	{"L Key Scale",	EditOPParameter,	0,	DEXED_OP_SCL_LEFT_CURVE},
-	{"R Key Scale",	EditOPParameter,	0,	DEXED_OP_SCL_RGHT_CURVE},
-	{"Rate Scaling",EditOPParameter,	0,	DEXED_OP_OSC_RATE_SCALE},
-	{"A Mod Sens.",	EditOPParameter,	0,	DEXED_OP_AMP_MOD_SENS},
-	{"K Vel. Sens.",EditOPParameter,	0,	DEXED_OP_KEY_VEL_SENS},
-	{"Enable", EditOPParameter, 0, DEXED_OP_ENABLE},
+	{"Output Level",EditOPParameter,	0,	DEXED_OP_OUTPUT_LEV,	"OutL"},
+	{"Freq Coarse",	EditOPParameter,	0,	DEXED_OP_FREQ_COARSE,	"FrC"},
+	{"Freq Fine",	EditOPParameter,	0,	DEXED_OP_FREQ_FINE,		"FrF"},
+	{"Osc Detune",	EditOPParameter,	0,	DEXED_OP_OSC_DETUNE,	"OsDT"},
+	{"Osc Mode",	EditOPParameter,	0,	DEXED_OP_OSC_MODE,		"OsM"},
+	{"EG Rate 1",	EditOPParameter,	0,	DEXED_OP_EG_R1,			"R1"},
+	{"EG Rate 2",	EditOPParameter,	0,	DEXED_OP_EG_R2,			"R2"},
+	{"EG Rate 3",	EditOPParameter,	0,	DEXED_OP_EG_R3,			"R3"},
+	{"EG Rate 4",	EditOPParameter,	0,	DEXED_OP_EG_R4,			"R4"},
+	{"EG Level 1",	EditOPParameter,	0,	DEXED_OP_EG_L1,			"L1"},
+	{"EG Level 2",	EditOPParameter,	0,	DEXED_OP_EG_L2,			"L2"},
+	{"EG Level 3",	EditOPParameter,	0,	DEXED_OP_EG_L3,			"L3"},
+	{"EG Level 4",	EditOPParameter,	0,	DEXED_OP_EG_L4,			"L4"},
+	{"Break Point",	EditOPParameter,	0,	DEXED_OP_LEV_SCL_BRK_PT,	"BP"},
+	{"L Key Depth",	EditOPParameter,	0,	DEXED_OP_SCL_LEFT_DEPTH,	"LDep"},
+	{"R Key Depth",	EditOPParameter,	0,	DEXED_OP_SCL_RGHT_DEPTH,	"RDep"},
+	{"L Key Scale",	EditOPParameter,	0,	DEXED_OP_SCL_LEFT_CURVE,	"LSca"},
+	{"R Key Scale",	EditOPParameter,	0,	DEXED_OP_SCL_RGHT_CURVE,	"RSca"},
+	{"Rate Scaling",EditOPParameter,	0,	DEXED_OP_OSC_RATE_SCALE,	"RS"},
+	{"A Mod Sens.",	EditOPParameter,	0,	DEXED_OP_AMP_MOD_SENS,		"AMS"},
+	{"K Vel. Sens.",EditOPParameter,	0,	DEXED_OP_KEY_VEL_SENS,		"KVS"},
+	{"Enable", EditOPParameter, 0, DEXED_OP_ENABLE,						"OPEn"},
 	{0}
 };
 
@@ -766,7 +766,7 @@ void CUIMenu::ShowCPUTemp (CUIMenu *pUIMenu, TMenuEvent Event)
 	case MenuEventUpdate:
 	case MenuEventUpdateParameter:
 		break;
-
+	
 	default:
 		return;
 	}
@@ -776,7 +776,7 @@ void CUIMenu::ShowCPUTemp (CUIMenu *pUIMenu, TMenuEvent Event)
 	char info[17];
   	snprintf(info, sizeof(info), "%d/%d C", pStatus->nCPUTemp.load(), pStatus->nCPUMaxTemp);
 
-	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection].Name,
 				      info,
 				      pUIMenu->m_nCurrentSelection > 0, !!pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection+1].Name);
@@ -803,7 +803,7 @@ void CUIMenu::ShowCPUSpeed (CUIMenu *pUIMenu, TMenuEvent Event)
 	char info[17];
   	snprintf(info, sizeof(info), "%d/%d MHz", pStatus->nCPUClockRate.load() / 1000000, pStatus->nCPUMaxClockRate / 1000000);
 
-	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection].Name,
 				      info,
 				      pUIMenu->m_nCurrentSelection > 0, !!pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection+1].Name);
@@ -833,7 +833,7 @@ void CUIMenu::ShowIPAddr (CUIMenu *pUIMenu, TMenuEvent Event)
 		IPAddr.Format(&IPString);
 	}
 
-	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection].Name,
 				      (const char*)IPString,
 				      pUIMenu->m_nCurrentSelection > 0, !!pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection+1].Name);
@@ -855,10 +855,78 @@ void CUIMenu::ShowVersion (CUIMenu *pUIMenu, TMenuEvent Event)
 		return;
 	}
 
-	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection].Name,
 				      VERSION,
 				      pUIMenu->m_nCurrentSelection > 0, !!pUIMenu->m_pCurrentMenu[pUIMenu->m_nCurrentSelection+1].Name);
+}
+
+const void CUIMenu::GetParameterInfo (CUIMenu::TCParameterInfo *pParam)
+{
+	static const CUIMenu::TMenuItem *globalSources[] = {
+//#ifdef ARM_ALLOW_MULTI_CORE
+//		s_PlateReverbMenu,
+//		s_MasterEQMenu,
+//		s_MasterCompressorMenu,
+//#endif
+		0};
+	static const CUIMenu::TMenuItem *tgSources[] = {s_TGMenu, s_EditPortamentoMenu, s_EditPitchBendMenu, s_ModulationMenu, s_MIDIMenu, s_EQMenu, s_EditCompressorMenu, 0};
+	static const CUIMenu::TMenuItem *voiceSources[] = {s_EditVoiceMenu + 6, 0}; // skip Operators
+	static const CUIMenu::TMenuItem *opSources[] = {s_OperatorMenu, 0};
+	const CUIMenu::TMenuItem **pSources = NULL;
+	const CUIMenu::TParameter *pInfo = NULL;
+
+	switch (pParam->Type)
+	{
+	case ParameterGlobal:
+		pSources = globalSources;
+		pInfo = s_GlobalParameter;
+		break;
+	case ParameterTG:
+		pSources = tgSources;
+		pInfo = s_TGParameter;
+		break;
+	case ParameterVoice:
+		pSources = voiceSources;
+		pInfo = s_VoiceParameter;
+		break;
+	case ParameterOP:
+		pSources = opSources;
+		pInfo = s_OPParameter;
+		break;
+	default:
+		return;
+	}
+
+	pParam->Min = pInfo[pParam->Parameter].Minimum;
+	pParam->Max = pInfo[pParam->Parameter].Maximum;
+	if (!pParam->ToString)
+		pParam->ToString = pInfo[pParam->Parameter].ToString;
+
+	// There are some parameters without entry eg TGParameterMWRange
+	// skip them
+	if (pParam->Name && pParam->Short)
+		return;
+
+	for (const CUIMenu::TMenuItem **source = pSources; *source; ++source)
+		for (const CUIMenu::TMenuItem *m = *source; m->Name; ++m)
+			if (m->Parameter == pParam->Parameter)
+			{
+				if (!pParam->Name)
+					pParam->Name = m->Name;
+				if (!pParam->Short)
+					pParam->Short = m->Short;
+				return;
+			}
+
+	pParam->Type = ParameterNone;
+	pParam->Parameter = 0;
+}
+
+const void CUIMenu::GetParameterInfos (CUIMenu::TCParameterInfo *pParamInfo, size_t n)
+{
+	for (size_t i = 0; i < n; ++i)
+		GetParameterInfo(&pParamInfo[i]);
 }
 
 CUIMenu::CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed, CConfig *pConfig)
@@ -970,6 +1038,26 @@ void CUIMenu::EventHandler (TMenuEvent Event)
 	default:
 		if (m_pParentMenu[m_nCurrentMenuItem].Handler)
 			(*m_pParentMenu[m_nCurrentMenuItem].Handler) (this, Event);
+		break;
+	}
+
+	switch (Event)
+	{
+	case MenuEventBack:
+	case MenuEventHome:
+	case MenuEventSelect:
+		if (m_pCurrentMenu == s_MainMenu)
+			m_pMiniDexed->UpdateDAWMenu (PageMain, 0, 0, 0);
+		//else if (m_pCurrentMenu == s_EffectsMenu)
+		//	m_pMiniDexed->UpdateDAWMenu (PageEffect, 0, 0, 0);
+		else if (m_pCurrentMenu == s_TGMenu)
+			m_pMiniDexed->UpdateDAWMenu (PageTG, 0, 0, m_nCurrentParameter + 1);
+		else if (m_pCurrentMenu == s_EditVoiceMenu)
+			m_pMiniDexed->UpdateDAWMenu (PageVoice, 0, 0, m_nMenuStackParameter[m_nCurrentMenuDepth - 1] + 1);
+		else if (m_pCurrentMenu == s_OperatorMenu)
+			m_pMiniDexed->UpdateDAWMenu (PageOP, 0, m_nCurrentParameter, m_nMenuStackParameter[m_nCurrentMenuDepth - 2] + 1);
+		break;
+	default:
 		break;
 	}
 }
@@ -1120,7 +1208,7 @@ void CUIMenu::MenuHandler (CUIMenu *pUIMenu, TMenuEvent Event)
 			if (nTGLink) selectionName += ToTGLinkName(nTGLink, 0);
 		}
 
-		pUIMenu->m_pUI->DisplayWrite (
+		pUIMenu->m_pMiniDexed->DisplayWrite (
 			menuName.c_str(),
 			"",
 			selectionName.c_str(),
@@ -1181,7 +1269,7 @@ void CUIMenu::EditGlobalParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->GetParameter (Param),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (pMenuName,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pMenuName,
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1228,7 +1316,7 @@ void CUIMenu::EditVoiceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 	std::string Value =   std::to_string (nValue+1) + "="
 		       + pUIMenu->m_pMiniDexed->GetSysExFileLoader ()->GetBankName (nValue);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > 0, nValue < (int) CSysExFileLoader::MaxVoiceBankID);
@@ -1311,7 +1399,7 @@ void CUIMenu::EditProgramNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 
 		std::string Value = pUIMenu->m_pMiniDexed->GetVoiceName (nTG);
 
-		pUIMenu->m_pUI->DisplayWrite (TG.c_str(),
+		pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str(),
 					  voice.c_str(),
 					  Value.c_str(),
 					  nValue > 0, nValue < (int) CSysExFileLoader::VoicesPerBank);
@@ -1374,7 +1462,7 @@ void CUIMenu::EditTGParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->GetTGParameter (Param, nTG),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1437,7 +1525,7 @@ void CUIMenu::EditTGParameter2 (CUIMenu *pUIMenu, TMenuEvent Event) // second me
 		pUIMenu->m_pMiniDexed->GetTGParameter (Param, nTG),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1487,7 +1575,7 @@ void CUIMenu::EditFXParameter2 (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->GetFXParameter (Param, nFX),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (FX.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (FX.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1537,7 +1625,7 @@ void CUIMenu::EditFXParameterG (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->GetFXParameter (Param, nFX),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (FX.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (FX.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1592,7 +1680,7 @@ void CUIMenu::EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 
 	std::string Value = GetVoiceValueString (nParam, nValue, pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1696,7 +1784,7 @@ void CUIMenu::EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event)
 		Value = GetOPValueString (nParam, nValue, pUIMenu->m_pConfig->GetLCDColumns() - 2);
 	}
 
-	pUIMenu->m_pUI->DisplayWrite (OP.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (OP.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);
@@ -1715,7 +1803,7 @@ void CUIMenu::SavePerformance (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_MenuStackParent[pUIMenu->m_nCurrentMenuDepth-1]
 			[pUIMenu->m_nMenuStackItem[pUIMenu->m_nCurrentMenuDepth-1]].Name;
 
-	pUIMenu->m_pUI->DisplayWrite (pMenuName,
+	pUIMenu->m_pMiniDexed->DisplayWrite (pMenuName,
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      bOK ? "Completed" : "Error",
 				      false, false);
@@ -2685,7 +2773,7 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 			{
 				pUIMenu->m_nSelectedPerformanceID = 0;
 				pUIMenu->m_bConfirmDeletePerformance=false;
-				pUIMenu->m_pUI->DisplayWrite ("", "Delete", pUIMenu->m_pMiniDexed->DeletePerformance(nValue) ? "Completed" : "Error", false, false);
+				pUIMenu->m_pMiniDexed->DisplayWrite ("", "Delete", pUIMenu->m_pMiniDexed->DeletePerformance(nValue) ? "Completed" : "Error", false, false);
 				pUIMenu->m_bSplashShow=true;
 				CTimer::Get ()->StartKernelTimer (MSEC2HZ (1500), TimerHandlerNoBack, 0, pUIMenu);
 				return;
@@ -2718,13 +2806,13 @@ void CUIMenu::PerformanceMenu (CUIMenu *pUIMenu, TMenuEvent Event)
 			nPSelected += " [L]";
 		}
 					
-		pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name, nPSelected.c_str(),
+		pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name, nPSelected.c_str(),
 						  Value.c_str (), true, true);
 //						 (int) nValue > 0, (int) nValue < (int) pUIMenu->m_pMiniDexed->GetLastPerformance());
 	}
 	else
 	{
-		pUIMenu->m_pUI->DisplayWrite ("", "Delete?", pUIMenu->m_bConfirmDeletePerformance ? "Yes" : "No", false, false);
+		pUIMenu->m_pMiniDexed->DisplayWrite ("", "Delete?", pUIMenu->m_bConfirmDeletePerformance ? "Yes" : "No", false, false);
 	}
 }
 
@@ -2806,7 +2894,7 @@ void CUIMenu::EditPerformanceBankNumber (CUIMenu *pUIMenu, TMenuEvent Event)
 		nPSelected += " [L]";
 	}
 
-	pUIMenu->m_pUI->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name, nPSelected.c_str(),
+	pUIMenu->m_pMiniDexed->DisplayWrite (pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name, nPSelected.c_str(),
 							Value.c_str (), true, true);
 }
 
@@ -2917,7 +3005,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 			pUIMenu->m_pMiniDexed->SetNewPerformanceName(pUIMenu->m_InputText);
 			bOK = pUIMenu->m_pMiniDexed->SavePerformanceNewFile ();
 			MsgOk=bOK ? "Completed" : "Error";
-			pUIMenu->m_pUI->DisplayWrite (OkTitleR.c_str(), OkTitleL.c_str(), MsgOk.c_str(), false, false);
+			pUIMenu->m_pMiniDexed->DisplayWrite (OkTitleR.c_str(), OkTitleL.c_str(), MsgOk.c_str(), false, false);
 			CTimer::Get ()->StartKernelTimer (MSEC2HZ (1500), TimerHandler, 0, pUIMenu);
 			return;
 		}
@@ -2968,7 +3056,7 @@ void CUIMenu::InputTxt (CUIMenu *pUIMenu, TMenuEvent Event)
 		}	
 		
 	Value = Value + " " + escCursor ;
-	pUIMenu->m_pUI->DisplayWrite (MenuTitleR.c_str(),MenuTitleL.c_str(), Value.c_str(), false, false);
+	pUIMenu->m_pMiniDexed->DisplayWrite (MenuTitleR.c_str(),MenuTitleL.c_str(), Value.c_str(), false, false);
 	
 	
 }
@@ -3026,7 +3114,7 @@ void CUIMenu::EditTGParameterModulation (CUIMenu *pUIMenu, TMenuEvent Event)
 		pUIMenu->m_pMiniDexed->GetTGParameter (Param, nTG),
 		pUIMenu->m_pConfig->GetLCDColumns() - 2);
 
-	pUIMenu->m_pUI->DisplayWrite (TG.c_str (),
+	pUIMenu->m_pMiniDexed->DisplayWrite (TG.c_str (),
 				      pUIMenu->m_pParentMenu[pUIMenu->m_nCurrentMenuItem].Name,
 				      Value.c_str (),
 				      nValue > rParam.Minimum, nValue < rParam.Maximum);

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -56,11 +56,46 @@ public:
 		MenuEventUnknown
 	};
 
+	typedef std::string TToString (int nValue, int nWidth);
+
+	enum TCPageType
+	{
+		PageMain,
+		PageEffect,
+		PageTG,
+		PageVoice,
+		PageOP,
+	};
+
+	enum TCParameterType
+	{
+		ParameterNone,
+		ParameterGlobal,
+		ParameterTG,
+		ParameterVoice,
+		ParameterOP,
+	};
+
+	struct TCParameterInfo {
+		TCParameterType Type;
+		unsigned Parameter;
+		const char* Name;
+		const char* Short;
+		u8 ChG;
+		u8 TG;
+		u8 OP;
+		int Min;
+		int Max;
+		TToString *ToString;
+	};
+
 public:
 	CUIMenu (CUserInterface *pUI, CMiniDexed *pMiniDexed, CConfig *pConfig);
 
 	void EventHandler (TMenuEvent Event);
 	
+	const void GetParameterInfos (CUIMenu::TCParameterInfo *pParamInfo, size_t n);
+
 private:
 	typedef void TMenuHandler (CUIMenu *pUIMenu, TMenuEvent Event);
 
@@ -70,14 +105,13 @@ private:
 		TMenuHandler *Handler;
 		const TMenuItem *MenuItem;
 		unsigned Parameter;
+		const char *Short;
 		TMenuHandler* OnSelect;
 		TMenuHandler* StepDown;
 		TMenuHandler* StepUp;
 		unsigned Parameter2;
 		bool ShowDirect;
 	};
-
-	typedef std::string TToString (int nValue, int nWidth);
 
 	struct TParameter
 	{
@@ -161,7 +195,8 @@ private:
 	static void StepDownEffect (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void StepUpEffect (CUIMenu *pUIMenu, TMenuEvent Event);
 	static bool FXSlotFilter (CUIMenu *pUIMenu, TMenuEvent Event, int nValue);
-
+	 
+	const void GetParameterInfo (TCParameterInfo *pParam);
 private:
 	CUserInterface *m_pUI;
 	CMiniDexed *m_pMiniDexed;

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -217,6 +217,16 @@ void CUserInterface::LoadDefaultScreen ()
 	}
 }
 
+void CUserInterface::MIDIEventHandler (CUIMenu::TMenuEvent Event)
+{
+	m_Menu.EventHandler (Event);
+}
+
+const void CUserInterface::GetParameterInfos (CUIMenu::TCParameterInfo *pParamInfo, size_t n)
+{
+	m_Menu.GetParameterInfos (pParamInfo, n);
+}
+
 void CUserInterface::Process (void)
 {
 	if (m_pLCDBuffered)
@@ -232,6 +242,7 @@ void CUserInterface::Process (void)
 void CUserInterface::ParameterChanged (void)
 {
 	m_Menu.EventHandler (CUIMenu::MenuEventUpdateParameter);
+	m_pMiniDexed->UpdateDAWState ();
 }
 
 void CUserInterface::DisplayChanged (void)

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -60,6 +60,10 @@ public:
 	// To be called from the MIDI device on reception of a MIDI CC message
 	void UIMIDICmdHandler (unsigned nMidiCh, unsigned nMidiType, unsigned nMidiData1, unsigned nMidiData2);
 
+	void MIDIEventHandler (CUIMenu::TMenuEvent Event);
+
+	const void GetParameterInfos (CUIMenu::TCParameterInfo *pParamInfo, size_t n);
+
 private:
 	void LCDWrite (const char *pString);		// Print to optional HD44780 display
 


### PR DESCRIPTION
This feature can be enabled in the minidexed.ini with:
```
DAWControllerEnabled=1
```

## Features

### Controller Display, Main Encoder
The controller display in DAW mode shows the DreamDexed menu.

With the main encoder you can navigate in the menu.

The Home is the shift+Main click

Supported:
- MiniLab 3 (tested)
- KeyLab mkII (tested)
- Keylab Essential
- Keylab Essential 3

### MiniLab 3 features:

#### Encoders

By holding down shift will bring up an overlay menu, where you can see and adjust what the encoders do.

You can use the main encoder to select the current encoding page.

Short pressing the shift will show the actual values.

Holding down the shift will goes back to the normal menu.

This overlay menu is context-aware, it is different if you are in the effect menu, or in a TG menu.

If you are in a TG menu, it only affects the selected TG.

If you are in the main menu, it affects the TGs on the first TG's channel.

- Main Overlay 1 (default)
  - Cutoff, Resonance, ReverbSend, None
  - PortamentoTime, Program, Volume, MasterVolume
  - Faders: ChG 1 Vol, ChG 2 Vol, ChG 3 Vol, ChG 4 Vol

- Effect Overlay 1
  - ReverbEnable, ReverbSize, ReverbHighDamp, ReverbLowDamp
  - ReverbLowPass, ReverbDiffusion, ReverbLevel, None
  - Faders: ReverbSize, ReverbHighDamp, ReverbLowDamp, ReverbLevel

- Effect Overlay 2
  - MasterEQLow, MasterEQMid, MasterEQHigh, MasterEQGain
  - MasterEQLowMidFreq, MasterEQMidHighFreq, None, None
  - Faders: MasterEQLow, MasterEQMid, MasterEQHigh, MasterEQGain

- Effect Overlay 3
  - LimiterEnable, LimiterPreGain, LimiterThresh, LimiterRatio
  - LimiterAttack, LimiterRelease, LimiterHPFilter, None
  - Faders: LimiterPreGain, LimiterThresh, LimiterAttack, LimiterRelease

- Main Overlay 2
  - Pan1, Pan2, Pan3, Pan4
  - Det1, Det2, Det3, Det4
  - Faders: TG1 Vol, TG2 Vol, TG3 Vol, TG4 Vol

- Main Overlay 3
  - Pan5, Pan6, Pan7, Pan8
  - Det5, Det6, Det7, Det8
  - Faders: TG5 Vol, TG6 Vol, TG7 Vol, TG8 Vol

- TG Overlay 1
  - Cutoff, Resonance, ReverbSend, MasterTune
  - PortamentoTime, Program, Volume, Pan
  - Faders: Cutoff, Resonance, ReverbSend, Volume

- TG Overlay 2
  - MIDIChannel, None, None, PitchBendRange
  - PortamentoGlissando, MonoMode, None, PitchBendStep

- TG Overlay 3
  - TGEQLow, TGEQMid, TGEQHigh, TGEQGain
  - TGEQLowMidFreq, TGEQMidHighFreq, None, None
  - Faders: TGEQLow, TGEQMid, TGEQHigh, TGEQGain

- TG Overlay 4
  - CompressorEnable, CompressorPreGain, CompressorThresh, CompressorRatio
  - CompressorAttack, CompressorRelease, CompressorMakeupGain, None
  - Faders: CompressorPreGain, CompressorThresh, CompressorAttack, CompressorRelease

- TG Overlay 5
  - MWRange, MWPitch, FCRange, FCPitch
  - MWEGBias, MWAmplitude, FCEGBias, FCAmplitude

- TG Overlay 6
  - BCRange, BCPitch, ATRange, ATPitch
  - BCEGBias, BCAmplitude, ATEGBias, ATAmplitude

- Voice Overlay 1
  - ALGORITHM, FEEDBACK, TRANSPOSE, None,
  - None, None, None, None

- Voice Overlay 2
  - PITCH_EG_R1, PITCH_EG_R2, PITCH_EG_R3, PITCH_EG_R4
  - PITCH_EG_L1, PITCH_EG_L2, PITCH_EG_L3, PITCH_EG_L4
  - Faders: PITCH_EG_L1, PITCH_EG_L2, PITCH_EG_L3, PITCH_EG_L4

- Voice Overlay 3
  - OSC_KEY_SYNC, LFO_SPEED, LFO_DELAY, LFO_PITCH_MOD_DEP
  - LFO_SYNC, LFO_WAVE, LFO_PITCH_MOD_SENS, LFO_AMP_MOD_DEP

- OP Overlay 1
  - OP_OUTPUT_LEV, OP_FREQ_COARSE, OP_FREQ_FINE, OP_OSC_DETUNE,
  - OP_OSC_MODE, OP_ENABLE, None, None

- OP Overlay 2
  - OP_EG_R1, OP_EG_R2, P_EG_R3, OP_EG_R4
  - OP_EG_L1, OP_EG_L2, OP_EG_L3, OP_EG_L4,
  - Faders: OP_EG_L1, OP_EG_L2, OP_EG_L3, OP_EG_L4,

- OP Overlay 3
  - OP_LEV_SCL_BRK_PT, OP_SCL_LEFT_DEPTH, OP_SCL_RGHT_DEPTH, OP_AMP_MOD_SENS
  - OP_OSC_RATE_SCALE, OP_SCL_LEFT_CURVE, OP_SCL_RGHT_CURVE, OP_KEY_VEL_SENS

In the Main overlay you can reach the TG and voice overlays also.

In the voice overlay there is a page for every OP control also, with the 6 operator and with an encoder which sets all.

#### Pads on Bank A
- Mono/Poly mode
- Portamento enable/disable, hard press to enable/disable Portamento Glissando
- Sostenuto
- Sustain
- All Sound Off
- Hold2
- None
- Channel AfterTouch Pad

#### Pads on Bank B
- Short press a TG will enable/disable that TG
- Long press will enable/disable all the TG on the TG's channel
- Hard press will enable only that TG (it uses the pad's AT messsages)


### KeyLab mkII features

#### Faders
- The faders 1-8 adjust the volume of the MIDI channels of the current performance
- The fader 9 adjusts the master volume.

#### DAW buttons
- Mono/Poly mode
- Portamento enable/disable, hard press to enable/disable Portamento Glissando
- Sostenuto
- Sustain
- Hold2

#### Track select buttons
- Short press a TG will enable/disable that TG
- Long press will enable only that TG