### PR TITLE
USB Boot: check boot-mode to use the appropriate root drive

### DIFF
--- a/src/circle_stdlib_app.h
+++ b/src/circle_stdlib_app.h
@@ -152,9 +152,6 @@ private:
         char const *mpPartitionName;
 
 public:
-        // TODO transform to constexpr
-        // constexpr char static DefaultPartition[] = "emmc1-1";
-#define CSTDLIBAPP_LEGACY_DEFAULT_PARTITION "emmc1-1"
 #define CSTDLIBAPP_DEFAULT_PARTITION "SD:"
 
         CStdlibAppStdio (const char *kernel,
@@ -193,12 +190,6 @@ public:
                 }
 
                 char const *partitionName = mpPartitionName;
-
-                // Recognize the old default partion name
-                if (strcmp(partitionName, CSTDLIBAPP_LEGACY_DEFAULT_PARTITION) == 0)
-                {
-                        partitionName = CSTDLIBAPP_DEFAULT_PARTITION;
-                }
 
                 if (f_mount (&mFileSystem, partitionName, 1) != FR_OK)
                 {


### PR DESCRIPTION
Until now, USB was only used as a root drive if SD was not available.

If USB boot is primary and there is an SD card in it, use the USB drive as the root drive also.
BOOT_ORDER can be set in RPi4 and RPi5.