### PR TITLE
UI: add Master Volume shortcut

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -188,6 +188,7 @@ void CConfig::Load()
 	m_nButtonPinBack = m_Properties.GetNumber("ButtonPinBack", 11);
 	m_nButtonPinSelect = m_Properties.GetNumber("ButtonPinSelect", 11);
 	m_nButtonPinHome = m_Properties.GetNumber("ButtonPinHome", 11);
+	m_nButtonPinMasterVol = m_Properties.GetNumber("ButtonPinMasterVol", 0);
 	m_nButtonPinShortcut = m_Properties.GetNumber("ButtonPinShortcut", 11);
 
 	m_ButtonActionPrev = m_Properties.GetString("ButtonActionPrev", "");
@@ -195,6 +196,7 @@ void CConfig::Load()
 	m_ButtonActionBack = m_Properties.GetString("ButtonActionBack", "doubleclick");
 	m_ButtonActionSelect = m_Properties.GetString("ButtonActionSelect", "click");
 	m_ButtonActionHome = m_Properties.GetString("ButtonActionHome", "longpress");
+	m_ButtonActionMasterVol = m_Properties.GetString("ButtonActionMasterVol", "");
 
 	m_nDoubleClickTimeout = m_Properties.GetSignedNumber("DoubleClickTimeout", 400);
 	m_nLongPressTimeout = m_Properties.GetSignedNumber("LongPressTimeout", 600);
@@ -222,12 +224,14 @@ void CConfig::Load()
 	m_nMIDIButtonBack = m_Properties.GetNumber("MIDIButtonBack", 0);
 	m_nMIDIButtonSelect = m_Properties.GetNumber("MIDIButtonSelect", 0);
 	m_nMIDIButtonHome = m_Properties.GetNumber("MIDIButtonHome", 0);
+	m_nMIDIButtonMasterVol = m_Properties.GetNumber("MIDIButtonMasterVol", 0);
 
 	m_MIDIButtonActionPrev = m_Properties.GetString("MIDIButtonActionPrev", "");
 	m_MIDIButtonActionNext = m_Properties.GetString("MIDIButtonActionNext", "");
 	m_MIDIButtonActionBack = m_Properties.GetString("MIDIButtonActionBack", "");
 	m_MIDIButtonActionSelect = m_Properties.GetString("MIDIButtonActionSelect", "");
 	m_MIDIButtonActionHome = m_Properties.GetString("MIDIButtonActionHome", "");
+	m_MIDIButtonActionMasterVol = m_Properties.GetString("MIDIButtonActionMasterVol", "");
 
 	m_nMIDIButtonPgmUp = m_Properties.GetNumber("MIDIButtonPgmUp", 0);
 	m_nMIDIButtonPgmDown = m_Properties.GetNumber("MIDIButtonPgmDown", 0);
@@ -636,6 +640,11 @@ unsigned CConfig::GetButtonPinHome() const
 	return m_nButtonPinHome;
 }
 
+unsigned CConfig::GetButtonPinMasterVol() const
+{
+	return m_nButtonPinMasterVol;
+}
+
 unsigned CConfig::GetButtonPinShortcut() const
 {
 	return m_nButtonPinShortcut;
@@ -664,6 +673,11 @@ const char *CConfig::GetButtonActionSelect() const
 const char *CConfig::GetButtonActionHome() const
 {
 	return m_ButtonActionHome.c_str();
+}
+
+const char *CConfig::GetButtonActionMasterVol() const
+{
+	return m_ButtonActionMasterVol.c_str();
 }
 
 int CConfig::GetDoubleClickTimeout() const
@@ -776,6 +790,11 @@ unsigned CConfig::GetMIDIButtonHome() const
 	return m_nMIDIButtonHome;
 }
 
+unsigned CConfig::GetMIDIButtonMasterVol() const
+{
+	return m_nMIDIButtonMasterVol;
+}
+
 const char *CConfig::GetMIDIButtonActionPrev() const
 {
 	return m_MIDIButtonActionPrev.c_str();
@@ -799,6 +818,11 @@ const char *CConfig::GetMIDIButtonActionSelect() const
 const char *CConfig::GetMIDIButtonActionHome() const
 {
 	return m_MIDIButtonActionHome.c_str();
+}
+
+const char *CConfig::GetMIDIButtonActionMasterVol() const
+{
+	return m_MIDIButtonActionMasterVol.c_str();
 }
 
 unsigned CConfig::GetMIDIButtonPgmUp() const

--- a/src/config.h
+++ b/src/config.h
@@ -189,6 +189,7 @@ public:
 	unsigned GetButtonPinBack() const;
 	unsigned GetButtonPinSelect() const;
 	unsigned GetButtonPinHome() const;
+	unsigned GetButtonPinMasterVol() const;
 	unsigned GetButtonPinShortcut() const;
 
 	// Action type for buttons: "click", "doubleclick", "longpress", ""
@@ -197,6 +198,7 @@ public:
 	const char *GetButtonActionBack() const;
 	const char *GetButtonActionSelect() const;
 	const char *GetButtonActionHome() const;
+	const char *GetButtonActionMasterVol() const;
 
 	// Timeouts for button events in milliseconds
 	int GetDoubleClickTimeout() const;
@@ -229,6 +231,7 @@ public:
 	unsigned GetMIDIButtonBack() const;
 	unsigned GetMIDIButtonSelect() const;
 	unsigned GetMIDIButtonHome() const;
+	unsigned GetMIDIButtonMasterVol() const;
 
 	// Action type for Midi buttons: "click", "doubleclick", "longpress", "dec", "inc", ""
 	const char *GetMIDIButtonActionPrev() const;
@@ -236,6 +239,7 @@ public:
 	const char *GetMIDIButtonActionBack() const;
 	const char *GetMIDIButtonActionSelect() const;
 	const char *GetMIDIButtonActionHome() const;
+	const char *GetMIDIButtonActionMasterVol() const;
 
 	// MIDI Button Program and TG Selection
 	unsigned GetMIDIButtonPgmUp() const;
@@ -361,6 +365,7 @@ private:
 	unsigned m_nButtonPinBack;
 	unsigned m_nButtonPinSelect;
 	unsigned m_nButtonPinHome;
+	unsigned m_nButtonPinMasterVol;
 	unsigned m_nButtonPinShortcut;
 	unsigned m_nButtonPinPgmUp;
 	unsigned m_nButtonPinPgmDown;
@@ -374,6 +379,7 @@ private:
 	std::string m_ButtonActionBack;
 	std::string m_ButtonActionSelect;
 	std::string m_ButtonActionHome;
+	std::string m_ButtonActionMasterVol;
 	std::string m_ButtonActionPgmUp;
 	std::string m_ButtonActionPgmDown;
 	std::string m_ButtonActionBankUp;
@@ -386,6 +392,7 @@ private:
 	std::string m_MIDIButtonActionBack;
 	std::string m_MIDIButtonActionSelect;
 	std::string m_MIDIButtonActionHome;
+	std::string m_MIDIButtonActionMasterVol;
 	std::string m_MIDIButtonActionPgmUp;
 	std::string m_MIDIButtonActionPgmDown;
 	std::string m_MIDIButtonActionBankUp;
@@ -404,6 +411,7 @@ private:
 	unsigned m_nMIDIButtonBack;
 	unsigned m_nMIDIButtonSelect;
 	unsigned m_nMIDIButtonHome;
+	unsigned m_nMIDIButtonMasterVol;
 	unsigned m_nMIDIButtonPgmUp;
 	unsigned m_nMIDIButtonPgmDown;
 	unsigned m_nMIDIButtonBankUp;

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -103,6 +103,8 @@ ButtonPinSelect=11
 ButtonActionSelect=click
 ButtonPinHome=11
 ButtonActionHome=doubleclick
+ButtonPinMasterVol=0
+ButtonActionMasterVol=
 ButtonPinShortcut=11
 # (Shortcut doesn't have an action)
 
@@ -149,6 +151,8 @@ MIDIButtonActionSelect=click
 # Home button
 MIDIButtonHome=50
 MIDIButtonActionHome=click
+MIDIButtonMasterVol=0
+MIDIButtonActionMasterVol=
 MIDIButtonPgmUp=51
 MIDIButtonActionPgmUp=click
 MIDIButtonPgmDown=52

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -365,6 +365,8 @@ bool CUIButtons::Initialize()
 	m_selectAction = CUIButton::triggerTypeFromString(m_pConfig->GetButtonActionSelect());
 	m_homePin = m_pConfig->GetButtonPinHome();
 	m_homeAction = CUIButton::triggerTypeFromString(m_pConfig->GetButtonActionHome());
+	m_masterVolPin = m_pConfig->GetButtonPinMasterVol();
+	m_masterVolAction = CUIButton::triggerTypeFromString(m_pConfig->GetButtonActionMasterVol());
 	m_pgmUpPin = m_pConfig->GetButtonPinPgmUp();
 	m_pgmUpAction = CUIButton::triggerTypeFromString(m_pConfig->GetButtonActionPgmUp());
 	m_pgmDownPin = m_pConfig->GetButtonPinPgmDown();
@@ -388,6 +390,8 @@ bool CUIButtons::Initialize()
 	m_selectMidiAction = CUIButton::triggerTypeFromString(m_pConfig->GetMIDIButtonActionSelect());
 	m_homeMidi = ccToMidiPin(m_pConfig->GetMIDIButtonHome());
 	m_homeMidiAction = CUIButton::triggerTypeFromString(m_pConfig->GetMIDIButtonActionHome());
+	m_masterVolMidi = ccToMidiPin(m_pConfig->GetMIDIButtonMasterVol());
+	m_masterVolMidiAction = CUIButton::triggerTypeFromString(m_pConfig->GetMIDIButtonActionMasterVol());
 	m_pgmUpMidi = ccToMidiPin(m_pConfig->GetMIDIButtonPgmUp());
 	m_pgmUpMidiAction = CUIButton::triggerTypeFromString(m_pConfig->GetMIDIButtonActionPgmUp());
 	m_pgmDownMidi = ccToMidiPin(m_pConfig->GetMIDIButtonPgmDown());
@@ -423,8 +427,8 @@ bool CUIButtons::Initialize()
 	// longpress. We may not initialise all of the buttons.
 	// MIDI buttons can be assigned to click, doubleclick, longpress, dec, inc
 	unsigned pins[MAX_BUTTONS] = {
-		m_prevPin, m_nextPin, m_backPin, m_selectPin, m_homePin, m_pgmUpPin, m_pgmDownPin, m_BankUpPin, m_BankDownPin, m_TGUpPin, m_TGDownPin,
-		m_prevMidi, m_nextMidi, m_backMidi, m_selectMidi, m_homeMidi, m_pgmUpMidi, m_pgmDownMidi, m_BankUpMidi, m_BankDownMidi, m_TGUpMidi, m_TGDownMidi};
+		m_prevPin, m_nextPin, m_backPin, m_selectPin, m_homePin, m_masterVolPin, m_pgmUpPin, m_pgmDownPin, m_BankUpPin, m_BankDownPin, m_TGUpPin, m_TGDownPin,
+		m_prevMidi, m_nextMidi, m_backMidi, m_selectMidi, m_homeMidi, m_masterVolMidi, m_pgmUpMidi, m_pgmDownMidi, m_BankUpMidi, m_BankDownMidi, m_TGUpMidi, m_TGDownMidi};
 	CUIButton::BtnTrigger triggers[MAX_BUTTONS] = {
 		// Normal buttons
 		m_prevAction,
@@ -432,6 +436,7 @@ bool CUIButtons::Initialize()
 		m_backAction,
 		m_selectAction,
 		m_homeAction,
+		m_masterVolAction,
 		m_pgmUpAction,
 		m_pgmDownAction,
 		m_BankUpAction,
@@ -444,6 +449,7 @@ bool CUIButtons::Initialize()
 		m_backMidiAction,
 		m_selectMidiAction,
 		m_homeMidiAction,
+		m_masterVolMidiAction,
 		m_pgmUpMidiAction,
 		m_pgmDownMidiAction,
 		m_BankUpMidiAction,
@@ -458,6 +464,7 @@ bool CUIButtons::Initialize()
 		CUIButton::BtnEventBack,
 		CUIButton::BtnEventSelect,
 		CUIButton::BtnEventHome,
+		CUIButton::BtnEventMasterVol,
 		CUIButton::BtnEventPgmUp,
 		CUIButton::BtnEventPgmDown,
 		CUIButton::BtnEventBankUp,
@@ -470,6 +477,7 @@ bool CUIButtons::Initialize()
 		CUIButton::BtnEventBack,
 		CUIButton::BtnEventSelect,
 		CUIButton::BtnEventHome,
+		CUIButton::BtnEventMasterVol,
 		CUIButton::BtnEventPgmUp,
 		CUIButton::BtnEventPgmDown,
 		CUIButton::BtnEventBankUp,

--- a/src/uibuttons.cpp
+++ b/src/uibuttons.cpp
@@ -118,11 +118,13 @@ void CUIButton::setLongPressEvent(BtnEvent longPressEvent)
 void CUIButton::setDecEvent(BtnEvent decEvent)
 {
 	m_decEvent = decEvent;
+	if (m_midipin) m_midipin->Write(MIDIPIN_CENTER);
 }
 
 void CUIButton::setIncEvent(BtnEvent incEvent)
 {
 	m_incEvent = incEvent;
+	if (m_midipin) m_midipin->Write(MIDIPIN_CENTER);
 }
 
 unsigned CUIButton::getPinNumber()

--- a/src/uibuttons.h
+++ b/src/uibuttons.h
@@ -28,8 +28,8 @@
 
 #define BUTTONS_UPDATE_NUM_TICKS 100
 #define DEBOUNCE_TIME 20
-#define MAX_GPIO_BUTTONS 11 // 5 UI buttons, 6 Program/Bank/TG Select buttons
-#define MAX_MIDI_BUTTONS 11
+#define MAX_GPIO_BUTTONS 12 // 6 UI buttons, 6 Program/Bank/TG Select buttons
+#define MAX_MIDI_BUTTONS 12
 #define MAX_BUTTONS (MAX_GPIO_BUTTONS + MAX_MIDI_BUTTONS)
 
 class CUIButtons;
@@ -55,13 +55,14 @@ public:
 		BtnEventBack = 3,
 		BtnEventSelect = 4,
 		BtnEventHome = 5,
-		BtnEventPgmUp = 6,
-		BtnEventPgmDown = 7,
-		BtnEventBankUp = 8,
-		BtnEventBankDown = 9,
-		BtnEventTGUp = 10,
-		BtnEventTGDown = 11,
-		BtnEventUnknown = 12
+		BtnEventMasterVol = 6,
+		BtnEventPgmUp = 7,
+		BtnEventPgmDown = 8,
+		BtnEventBankUp = 9,
+		BtnEventBankDown = 10,
+		BtnEventTGUp = 11,
+		BtnEventTGDown = 12,
+		BtnEventUnknown = 13
 	};
 
 	CUIButton();
@@ -154,6 +155,8 @@ private:
 	CUIButton::BtnTrigger m_selectAction;
 	unsigned m_homePin;
 	CUIButton::BtnTrigger m_homeAction;
+	unsigned m_masterVolPin;
+	CUIButton::BtnTrigger m_masterVolAction;
 
 	// Program and TG Selection buttons
 	unsigned m_pgmUpPin;
@@ -182,6 +185,8 @@ private:
 	CUIButton::BtnTrigger m_selectMidiAction;
 	unsigned m_homeMidi;
 	CUIButton::BtnTrigger m_homeMidiAction;
+	unsigned m_masterVolMidi;
+	CUIButton::BtnTrigger m_masterVolMidiAction;
 
 	unsigned m_pgmUpMidi;
 	CUIButton::BtnTrigger m_pgmUpMidiAction;

--- a/src/uimenu.cpp
+++ b/src/uimenu.cpp
@@ -1012,6 +1012,20 @@ void CUIMenu::EventHandler(TMenuEvent Event)
 		EventHandler(MenuEventUpdate);
 		break;
 
+	case MenuEventMasterVol:
+		EventHandler(MenuEventHome);
+
+		while (m_pCurrentMenu[m_nCurrentSelection].MenuItem != s_MixerMenu)
+			EventHandler(MenuEventStepUp);
+
+		EventHandler(MenuEventSelect);
+
+		while (m_pCurrentMenu[m_nCurrentSelection].Parameter != CMiniDexed::ParameterMasterVolume)
+			EventHandler(MenuEventStepUp);
+
+		EventHandler(MenuEventSelect);
+		break;
+
 	case MenuEventPgmUp:
 	case MenuEventPgmDown:
 		PgmUpDownHandler(Event);

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -45,6 +45,7 @@ public:
 		MenuEventSelect,
 		MenuEventBack,
 		MenuEventHome,
+		MenuEventMasterVol,
 		MenuEventStepDown,
 		MenuEventStepUp,
 		MenuEventPressAndStepDown,

--- a/src/userinterface.cpp
+++ b/src/userinterface.cpp
@@ -424,6 +424,10 @@ void CUserInterface::UIButtonsEventHandler(CUIButton::BtnEvent Event)
 		m_Menu.EventHandler(CUIMenu::MenuEventHome);
 		break;
 
+	case CUIButton::BtnEventMasterVol:
+		m_Menu.EventHandler(CUIMenu::MenuEventMasterVol);
+		break;
+
 	case CUIButton::BtnEventPgmUp:
 		m_Menu.EventHandler(CUIMenu::MenuEventPgmUp);
 		break;


### PR DESCRIPTION
New options in the minidexed.ini to open the master volume screen:

For GPIO:
```
ButtonPinMasterVol=<GPIO number>
ButtonActionMasterVol=click
```

For MIDI CC:
```
MIDIButtonMasterVol=<MIDI CC number>
MIDIButtonActionMasterVol=click
```

This also contains a fix for the dec/inc modes.
